### PR TITLE
Additional outputs

### DIFF
--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -27,6 +27,21 @@ output "NAT4EIP" {
   value       = module.aws-ia_vpc.NAT4EIP
 }
 
+output "private_subnet_route_tables" {
+  description = "Private subnet route tables"
+  value       = module.aws-ia_vpc.private_subnet_route_tables
+}
+
+output "private_subnets" {
+  description = "Private subnet ids"
+  value       = module.aws-ia_vpc.private_subnets
+}
+
+output "availability_zones" {
+  description = "all availability zone names used by subnets in this vpc"
+  value       = module.aws-ia_vpc.availability_zones
+}
+
 output "PrivateSubnet1ACIDR" {
   description = " Private subnet 1A CIDR in Availability Zone 1"
   value       = module.aws-ia_vpc.PrivateSubnet1ACIDR

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@
 ######################################
 terraform {
   required_version = ">= 1.0.0"
-  backend "remote" {}
 }
 
 provider "aws" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -10,7 +10,6 @@ terraform {
       version = ">= 3.49.0"
     }
   }
-  backend "remote" {}
 }
 
 provider "aws" {

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -17,6 +17,22 @@ output "private_subnets_B" {
   description = "List of IDs of privateB subnets"
   value       = aws_subnet.private_B.*.id
 }
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = flatten([compact(aws_subnet.private_A.*.id), compact(aws_subnet.private_B.*.id)])
+}
+output "private_subnet_route_tables" {
+  description = "List of IDs of private subnets"
+  value       = flatten([aws_route_table.private_A.*.id, aws_route_table.private_B.*.id])
+}
+output "availability_zones" {
+  description = "List of availability zones names for subnets in this vpc"
+  value       = compact(distinct(flatten([
+    aws_subnet.private_A.*.availability_zone,
+    aws_subnet.private_B.*.availability_zone,
+    aws_subnet.public.*.availability_zone
+  ])))
+}
 output "public_subnets" {
   description = "List of IDs of privateB subnets"
   value       = aws_subnet.public.*.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,21 @@ output "NAT4EIP" {
   value       = module.aws-vpc.NAT4EIP
 }
 
+output "private_subnet_route_tables" {
+  description = "Route tables for all private subnets"
+  value       = module.aws-vpc.private_subnet_route_tables
+}
+
+output "private_subnets" {
+  description = "ID's for all private subnets"
+  value       = module.aws-vpc.private_subnets
+}
+
+output "availability_zones" {
+  description = "List of availability zones names for subnets in this vpc"
+  value       = module.aws-vpc.availability_zones
+}
+
 output "PrivateSubnet1ACIDR" {
   description = " Private subnet 1A CIDR in Availability Zone 1"
   value       = module.aws-vpc.PrivateSubnet1ACIDR


### PR DESCRIPTION
Adds outputs that provide consolidated lists of:
* private_subnet_route_tables
* private_subnets
* availability_zones

These outputs are useful time savers for modules consuming the vpc module, so they don't need to construct lists from the individual outputs.

Also removes hardcoded backend declarations