### PR TITLE
fix nat gateway count based on test failures

### DIFF
--- a/modules/vpc/examples/fully_private/main.tf
+++ b/modules/vpc/examples/fully_private/main.tf
@@ -31,6 +31,7 @@ module "aws-ia_vpc" {
   create_igw                    = var.create_igw
   create_nat_gateways_private_a = var.create_nat_gateways_private_a
   create_nat_gateways_private_b = var.create_nat_gateways_private_b
+  private_subnet_b_cidrs        = ["10.0.112.0/20", "10.0.128.0/20", "10.0.144.0/20"]
 }
 
 output "igw_id" {

--- a/modules/vpc/locals.tf
+++ b/modules/vpc/locals.tf
@@ -1,10 +1,8 @@
 locals {
-  max_subnet_length = max(
-    length(local.public_subnet_cidrs),
+  max_private_subnet_length = max(
     length(local.private_subnet_a_cidrs),
     length(local.private_subnet_b_cidrs),
   )
-  nat_gateway_count = local.max_subnet_length
 
   # Use `local.vpc_id` to give a hint to Terraform that subnets should be deleted before secondary CIDR blocks can be free!
   vpc_id = element(
@@ -19,6 +17,7 @@ locals {
   private_subnet_a_cidrs = var.private_subnet_a_cidrs == null ? cidrsubnets(cidrsubnets(var.cidr, 2, 2)[1], 2, 2, 2) : var.private_subnet_a_cidrs
   private_subnet_b_cidrs = var.private_subnet_b_cidrs == null ? [] : var.private_subnet_b_cidrs
   availability_zones     = var.availability_zones == null ? data.aws_availability_zones.available.names : var.availability_zones
+  create_nat_gws         = var.create_vpc && var.create_igw && (var.create_nat_gateways_private_a || var.create_nat_gateways_private_b)
 
   # count variables
   vpc_count                   = var.create_vpc ? 1 : 0
@@ -27,6 +26,7 @@ locals {
   private_subnet_a_count      = var.create_vpc ? length(local.private_subnet_a_cidrs) : 0
   private_subnet_b_count      = var.create_vpc ? length(local.private_subnet_b_cidrs) : 0
   igw_count                   = var.create_igw && length(local.public_subnet_cidrs) > 0 ? local.vpc_count : 0
+  nat_gateway_count           = local.create_nat_gws ? local.max_private_subnet_length : 0
   public_route_table_count    = length(local.public_subnet_cidrs) > 0 ? local.vpc_count : 0
   private_a_nacl_count        = length(local.private_subnet_a_cidrs) > 0 ? local.vpc_count : 0
   private_b_nacl_count        = length(local.private_subnet_b_cidrs) > 0 ? local.vpc_count : 0

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -271,7 +271,7 @@ resource "aws_network_acl_rule" "private_b_outbound" {
 ##############
 
 resource "aws_eip" "nat" {
-  count = local.nat_gateway_private_a_count
+  count = local.nat_gateway_count
   vpc   = true
 
   tags = {
@@ -280,7 +280,7 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "nat_gw" {
-  count         = local.nat_gateway_private_a_count
+  count         = local.nat_gateway_count
   allocation_id = aws_eip.nat[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
   tags = {


### PR DESCRIPTION
tests created in #14 surfaced this issue. count for nat gw's was based only on private_a and the test module in examples did not provision private_b subnets