### PR TITLE
Chore/var-description

### DIFF
--- a/modules/vpc/examples/fully_private/main.tf
+++ b/modules/vpc/examples/fully_private/main.tf
@@ -1,24 +1,29 @@
 variable "region" {
-  type = string
+  description = "AWS region to create VPC in"
+  type        = string
 }
 
 variable "profile" {
-  type = string
+  description = "AWS CLI profile to use when calling AWS API's"
+  type        = string
 }
 
 variable "create_igw" {
-  type    = bool
-  default = false
+  description = "If set to false no IGW will be created for the public subnets. Setting this to false will also disable NAT gateways on private subnets, as NAT gateways require IGW in public subnets"
+  type        = bool
+  default     = false
 }
 
 variable "create_nat_gateways_private_b" {
-  type    = bool
-  default = false
+  description = "If set to false no NAT gateways will be created for the private_b subnets"
+  type        = bool
+  default     = false
 }
 
 variable "create_nat_gateways_private_a" {
-  type    = bool
-  default = false
+  description = "If set to false no NAT gateways will be created for the private_a subnets"
+  type        = bool
+  default     = false
 }
 
 provider "aws" {

--- a/modules/vpc/examples/minimal/main.tf
+++ b/modules/vpc/examples/minimal/main.tf
@@ -1,9 +1,11 @@
 variable "region" {
-  type = string
+  description = "AWS region to create VPC in"
+  type        = string
 }
 
 variable "profile" {
-  type = string
+  description = "AWS CLI profile to use when calling AWS API's"
+  type        = string
 }
 
 provider "aws" {

--- a/modules/vpc/examples/no_create/main.tf
+++ b/modules/vpc/examples/no_create/main.tf
@@ -1,9 +1,11 @@
 variable "region" {
-  type = string
+  description = "AWS region to create VPC in"
+  type        = string
 }
 
 variable "profile" {
-  type = string
+  description = "AWS CLI profile to use when calling AWS API's"
+  type        = string
 }
 
 provider "aws" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -5,8 +5,8 @@ variable "create_vpc" {
 }
 
 variable "name" {
-  type        = string
   description = "Will be used as a prefix for all resources that require a name field. Should be unique in the region."
+  type        = string
   default     = null
   validation {
     condition     = can(length(var.name) < 223) || var.name == null
@@ -15,8 +15,8 @@ variable "name" {
 }
 
 variable "tags" {
-  type        = map(string)
   description = "tags, which could be used for additional tags"
+  type        = map(string)
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,18 +5,18 @@ variable "create_vpc" {
 }
 
 variable "region" {
-  type        = string
   description = "AWS region to create VPC in"
+  type        = string
 }
 
 variable "profile" {
-  type        = string
   description = "AWS CLI profile to use when calling AWS API's"
+  type        = string
 }
 
 variable "tags" {
-  type        = map(string)
   description = "tags, which could be used for additional tags"
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
# Reference

[Terraform documentation - best practices for naming variables](https://www.terraform-best-practices.com/naming#variables)

# Changes made

1. Reorder variables to follow the recommended order for keys: `description`, `type`, `default`
2. Add `description` key for variables in the examples directory

