### PR TITLE
Added support for enabling flow logs

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -48,4 +48,11 @@ module "aws-ia_vpc" {
   instance_tenancy       = var.instance_tenancy
   public_subnet_tags     = tomap(var.public_subnet_tags)
   private_subnet_tags    = tomap(var.private_subnet_tags)
+  create_vpc_flow_logs   = var.create_vpc_flow_logs
+  flog_log_iam_role_arn  = var.flog_log_iam_role_arn
+  log_destination        = var.log_destination
+  log_destination_type   = var.log_destination_type
+  log_format             = var.log_format
+  traffic_type           = var.traffic_type
+  enriched_meta_data     = var.enriched_meta_data
 }

--- a/deploy/outputs.tf
+++ b/deploy/outputs.tf
@@ -211,3 +211,18 @@ output "public_subnet_route_table" {
   description = " Public subnet route table"
   value       = module.aws-ia_vpc.public_subnet_route_table
 }
+
+output "flow_log_id" {
+  description = "The Flow Log ID"
+  value       = module.aws-ia_vpc.flow_log_id
+}
+
+output "flow_log_arn" {
+  description = "The ARN of the Flow log."
+  value       = module.aws-ia_vpc.flow_log_arn
+}
+
+output "flow_log_destination" {
+  description = "The ARN of the logging destination."
+  value       = module.aws-ia_vpc.flow_log_destination
+}

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -81,3 +81,45 @@ variable "create_vpc" {
   type        = bool
   default     = true
 }
+
+variable "create_vpc_flow_logs" {
+  description = "Controls if VPC logs should be created for the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "log_destination" {
+  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-watch-logs, provide ARN of log group otherwise log group will be created for you."
+  type        = string
+  default     = null
+}
+
+variable "flog_log_iam_role_arn" {
+  description = "The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group."
+  type        = string
+  default     = null
+}
+
+variable "log_destination_type" {
+  description = "The type of the logging destination for flow log. Valid values: cloud-watch-logs, s3"
+  type        = string
+  default     = "cloud-watch-logs"
+}
+
+variable "traffic_type" {
+  description = "The type of traffic to capture in the flow log."
+  type        = string
+  default     = "ALL"
+}
+
+variable "log_format" {
+  description = "The fields to include in the flow log record, in the order in which they should appear."
+  type        = string
+  default     = null
+}
+
+variable "enriched_meta_data" {
+  description = "Controls if VPC logs should have enriched meta data fields."
+  type        = bool
+  default     = true
+}

--- a/main.tf
+++ b/main.tf
@@ -47,4 +47,11 @@ module "aws_vpc" {
   create_igw                    = var.create_igw
   create_nat_gateways_private_a = var.create_nat_gateways_private_a
   create_nat_gateways_private_b = var.create_nat_gateways_private_b
+  create_vpc_flow_logs          = var.create_vpc_flow_logs
+  flog_log_iam_role_arn         = var.flog_log_iam_role_arn
+  log_destination               = var.log_destination
+  log_destination_type          = var.log_destination_type
+  log_format                    = var.log_format
+  traffic_type                  = var.traffic_type
+  enriched_meta_data            = var.enriched_meta_data
 }

--- a/modules/vpc/examples/flow_log_destination_log_group/main.tf
+++ b/modules/vpc/examples/flow_log_destination_log_group/main.tf
@@ -1,0 +1,53 @@
+variable "region" {
+  type = string
+}
+
+variable "profile" {
+  type = string
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+
+variable "create_vpc_flow_logs" {
+  type    = bool
+  default = true
+}
+
+variable "log_destination_type" {
+  type    = string
+  default = "cloud-watch-logs"
+}
+
+variable "log_destination" {
+  type    = string
+  default = null
+}
+
+variable "flog_log_iam_role_arn" {
+  type    = string
+  default = null
+}
+
+module "aws-ia_vpc" {
+  source                = "../../"
+  create_vpc_flow_logs  = var.create_vpc_flow_logs
+  log_destination_type  = var.log_destination_type
+  log_destination       = var.log_destination
+  flog_log_iam_role_arn = var.flog_log_iam_role_arn
+}
+
+output "flow_log_id" {
+  value = module.aws-ia_vpc.flow_log_id
+}
+
+output "flow_log_arn" {
+  value = module.aws-ia_vpc.flow_log_arn
+}
+
+output "flow_log_destination" {
+  value = module.aws-ia_vpc.flow_log_destination
+}

--- a/modules/vpc/examples/flow_log_destination_s3/main.tf
+++ b/modules/vpc/examples/flow_log_destination_s3/main.tf
@@ -1,0 +1,47 @@
+variable "region" {
+  type = string
+}
+
+variable "profile" {
+  type = string
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.profile
+}
+
+
+variable "create_vpc_flow_logs" {
+  type    = bool
+  default = true
+}
+
+variable "log_destination_type" {
+  type    = string
+  default = "s3"
+}
+
+variable "log_destination" {
+  type    = string
+  default = null
+}
+
+module "aws-ia_vpc" {
+  source               = "../../"
+  create_vpc_flow_logs = var.create_vpc_flow_logs
+  log_destination_type = var.log_destination_type
+  log_destination      = var.log_destination
+}
+
+output "flow_log_id" {
+  value = module.aws-ia_vpc.flow_log_id
+}
+
+output "flow_log_arn" {
+  value = module.aws-ia_vpc.flow_log_arn
+}
+
+output "flow_log_destination" {
+  value = module.aws-ia_vpc.flow_log_destination
+}

--- a/modules/vpc/locals.tf
+++ b/modules/vpc/locals.tf
@@ -32,4 +32,12 @@ locals {
   private_b_nacl_count        = length(local.private_subnet_b_cidrs) > 0 ? local.vpc_count : 0
   nat_gateway_private_a_count = var.create_vpc && var.create_igw && var.create_nat_gateways_private_a ? length(local.private_subnet_a_cidrs) : 0
   nat_gateway_private_b_count = var.create_vpc && var.create_igw && var.create_nat_gateways_private_b ? length(local.private_subnet_b_cidrs) : 0
+
+  # flow log variables
+  create_log_group      = var.create_vpc_flow_logs && var.log_destination_type != "s3" && var.log_destination == null
+  create_log_bucket     = var.create_vpc_flow_logs && var.log_destination_type == "s3" && var.log_destination == null
+  create_flow_log_iam_role     = var.create_vpc_flow_logs && var.log_destination_type != "s3" && var.flog_log_iam_role_arn == null
+  log_destination       = (var.create_vpc_flow_logs && local.create_log_group ? aws_cloudwatch_log_group.flow_logs_log_group[0].arn : (local.create_log_bucket ? aws_s3_bucket.flow_logs_bucket[0].arn : var.log_destination))
+  flog_log_iam_role_arn = local.create_flow_log_iam_role ? aws_iam_role.flow_logs_role[0].arn : var.flog_log_iam_role_arn
+  log_format            = var.enriched_meta_data ? "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}" : var.log_format
 }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -232,3 +232,18 @@ output "private_b_nat_routes" {
   description = "Routes for NAT gateways attached to private_b subnets"
   value       = length(aws_route.private_b_nat_gateway[*]) > 0 ? aws_route.private_b_nat_gateway[*].id : []
 }
+
+output "flow_log_id" {
+  value       = try(aws_flow_log.flow_logs[0].id, "")
+  description = "The Flow Log ID"
+}
+
+output "flow_log_arn" {
+  value       = try(aws_flow_log.flow_logs[0].arn, "")
+  description = "The ARN of the Flow log"
+}
+
+output "flow_log_destination" {
+  value       = try(aws_flow_log.flow_logs[0].log_destination, "")
+  description = "The ARN of the logging destination."
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -207,3 +207,45 @@ variable "create_nat_gateways_private_b" {
   type        = bool
   default     = false
 }
+
+variable "create_vpc_flow_logs" {
+  description = "Controls if VPC logs should be created for the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "log_destination" {
+  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-wtch-logs, provide ARN of log group otherwise log group will be created for you."
+  type        = string
+  default     = null
+}
+
+variable "flog_log_iam_role_arn" {
+  description = "The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group."
+  type        = string
+  default     = null
+}
+
+variable "log_destination_type" {
+  description = "The type of the logging destination for flow log. Valid values: cloud-watch-logs, s3"
+  type        = string
+  default     = "cloud-watch-logs"
+}
+
+variable "traffic_type" {
+  description = "The type of traffic to capture in the flow log."
+  type        = string
+  default     = "ALL"
+}
+
+variable "log_format" {
+  description = "The fields to include in the flow log record, in the order in which they should appear."
+  type        = string
+  default     = null
+}
+
+variable "enriched_meta_data" {
+  description = "Controls if VPC logs should have enriched meta data fields."
+  type        = bool
+  default     = true
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -215,7 +215,7 @@ variable "create_vpc_flow_logs" {
 }
 
 variable "log_destination" {
-  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-wtch-logs, provide ARN of log group otherwise log group will be created for you."
+  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-watch-logs, provide ARN of log group otherwise log group will be created for you."
   type        = string
   default     = null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -196,3 +196,18 @@ output "public_subnet_route_table" {
   description = " Public subnet route table"
   value       = module.aws_vpc.public_subnet_route_table
 }
+
+output "flow_log_id" {
+  value       = module.aws_vpc.flow_log_id
+  description = "The Flow Log ID"
+}
+
+output "flow_log_arn" {
+  value       = module.aws_vpc.flow_log_arn
+  description = "The ARN of the Flow log."
+}
+
+output "flow_log_destination" {
+  value       = module.aws_vpc.flow_log_destination
+  description = "The ARN of the logging destination."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -207,3 +207,45 @@ variable "create_nat_gateways_private_b" {
   type        = bool
   default     = false
 }
+
+variable "create_vpc_flow_logs" {
+  description = "Controls if VPC logs should be created for the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "log_destination" {
+  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-wtch-logs, provide ARN of log group otherwise log group will be created for you."
+  type        = string
+  default     = null
+}
+
+variable "flog_log_iam_role_arn" {
+  description = "The ARN for the IAM role that's used to post flow logs to a CloudWatch Logs log group."
+  type        = string
+  default     = null
+}
+
+variable "log_destination_type" {
+  description = "The type of the logging destination for flow log. Valid values: cloud-watch-logs, s3"
+  type        = string
+  default     = "cloud-watch-logs"
+}
+
+variable "traffic_type" {
+  description = "The type of traffic to capture in the flow log."
+  type        = string
+  default     = "ALL"
+}
+
+variable "log_format" {
+  description = "The fields to include in the flow log record, in the order in which they should appear."
+  type        = string
+  default     = null
+}
+
+variable "enriched_meta_data" {
+  description = "Controls if VPC logs should have enriched meta data fields."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -215,7 +215,7 @@ variable "create_vpc_flow_logs" {
 }
 
 variable "log_destination" {
-  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-wtch-logs, provide ARN of log group otherwise log group will be created for you."
+  description = "The ARN of the flow log logging destination. If log_destination_type set to s3, provide the ARN of your bucket. Otherwise, a bucket will be created for you. If log_destination_type is set to cloud-watch-logs, provide ARN of log group otherwise log group will be created for you."
   type        = string
   default     = null
 }


### PR DESCRIPTION
- Support for enabling flow logs by specifying create_vpc_flow_logs flag
- Support for log destination (cloudwatch logs or s3)
- Dynamically creates bucket or log group if none specified
- Provides option for enriched meta data fields in flow logs