### PR TITLE
main

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tonynv @andrew-glenn @tbulding @aws-ia-terraform-core
+* @tonynv @andrew-glenn @tbulding @aws-ia/aws-ia-terraform-core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tonynv @andrew-glenn @tbulding
+* @tonynv @andrew-glenn @tbulding @aws-ia-terraform-core


### PR DESCRIPTION
- adding aws-ia-terraform-core team to CODEOWNERS
- fixing codeowner syntax
