### PR TITLE
VPC Subnets for AWS Transit Gateway Attachments should be a /28, also…

### DIFF
--- a/examples/transit_gateway/main.tf
+++ b/examples/transit_gateway/main.tf
@@ -14,17 +14,17 @@ module "vpc" {
     public = {
       netmask                   = 24
       nat_gateway_configuration = "single_az"
-      route_to_transit_gateway  = ["10.1.0.0/16"]
+      route_to_transit_gateway  = ["10.0.0.0/8"]
     }
 
     private = {
       netmask                  = 24
       route_to_nat             = true
-      route_to_transit_gateway = ["10.1.0.0/16"]
+      route_to_transit_gateway = ["10.0.0.0/8"]
     }
 
     transit_gateway = {
-      netmask                                         = 24
+      netmask                                         = 28
       transit_gateway_id                              = aws_ec2_transit_gateway.example.id
       route_to_nat                                    = false
       transit_gateway_default_route_table_association = true


### PR DESCRIPTION
VPC Subnets for AWS Transit Gateway Attachments should be a /28 (best practice), changed the /16 to a /8 for the route_to_transit_gateway to capture all 10.x.0.0/16 networks