### PR TITLE
Tags prefix

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -26,6 +26,8 @@ locals {
   cidr_block = var.vpc_ipv4_ipam_pool_id == null ? var.cidr_block : data.aws_vpc_ipam_preview_next_cidr.main[0].cidr
 
   create_flow_logs = (var.vpc_flow_logs == null || var.vpc_flow_logs.log_destination_type == "none") ? false : true
+
+  tags_prefix = var.tags_prefix == null ? "" : "${var.tags_prefix}-"
 }
 
 data "aws_availability_zones" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_subnet" "public" {
   cidr_block        = each.value
 
   tags = merge({
-    Name = "${local.subnet_names["public"]}-${each.key}" },
+    Name = "${local.tags_prefix}${local.subnet_names["public"]}-${each.key}" },
   module.tags.tags_aws)
 }
 
@@ -50,7 +50,7 @@ resource "awscc_ec2_route_table" "public" {
   vpc_id = local.vpc.id
 
   tags = concat(
-    [{ "key" = "Name", "value" = "${local.subnet_names["public"]}-${each.key}" }],
+    [{ "key" = "Name", "value" = "${local.tags_prefix}${local.subnet_names["public"]}-${each.key}" }],
     module.tags.tags
   )
 }
@@ -67,7 +67,7 @@ resource "aws_eip" "nat" {
   vpc      = true
 
   tags = merge({
-    Name = "nat-${local.subnet_names["public"]}-${each.key}"
+    Name = "${local.tags_prefix}nat-${local.subnet_names["public"]}-${each.key}"
   }, module.tags.tags_aws)
 }
 
@@ -78,7 +78,7 @@ resource "aws_nat_gateway" "main" {
   subnet_id     = aws_subnet.public[each.key].id
 
   tags = merge({
-    Name = "nat-${local.subnet_names["public"]}-${each.key}" },
+    Name = "${local.tags_prefix}nat-${local.subnet_names["public"]}-${each.key}" },
   module.tags.tags_aws)
 
   depends_on = [
@@ -124,7 +124,7 @@ resource "aws_subnet" "private" {
   map_public_ip_on_launch = false
 
   tags = merge({
-    Name = "${local.subnet_names["private"]}-${each.key}" },
+    Name = "${local.tags_prefix}${local.subnet_names["private"]}-${each.key}" },
   module.tags.tags_aws)
 
   depends_on = [
@@ -138,7 +138,7 @@ resource "awscc_ec2_route_table" "private" {
   vpc_id = local.vpc.id
 
   tags = concat(
-    [{ "key" = "Name", "value" = "${local.subnet_names["private"]}-${each.key}" }],
+    [{ "key" = "Name", "value" = "${local.tags_prefix}${local.subnet_names["private"]}-${each.key}" }],
     module.tags.tags
   )
 }
@@ -181,7 +181,7 @@ resource "aws_subnet" "tgw" {
   cidr_block        = each.value
 
   tags = merge({
-    Name = "${local.subnet_names["transit_gateway"]}-${each.key}" },
+    Name = "${local.tags_prefix}${local.subnet_names["transit_gateway"]}-${each.key}" },
   module.tags.tags_aws)
 }
 
@@ -191,7 +191,7 @@ resource "awscc_ec2_route_table" "tgw" {
   vpc_id = local.vpc.id
 
   tags = concat(
-    [{ "key" = "Name", "value" = "${local.subnet_names["transit_gateway"]}-${each.key}" }],
+    [{ "key" = "Name", "value" = "${local.tags_prefix}${local.subnet_names["transit_gateway"]}-${each.key}" }],
     module.tags.tags
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_prefix" {
+  description = "Prefix tag value to apply to all resources."
+  type        = string
+  default     = null
+}
+
 variable "vpc_flow_logs" {
   description = "Whether or not to create VPC flow logs and which type. Options: \"cloudwatch\", \"s3\", \"none\". By default creates flow logs to `cloudwatch`. Variable overrides null value types for some keys, defined in defaults.tf."
 


### PR DESCRIPTION
This is an enhancement that adds a prefix value to the tags for (almost) all resources. I think it improves the readability, especially when there are more than 1 VPCs (with multiple subnets) in the AWS account.
The **tags_prefix** value is declared inside the vpc module.
F.x.

```
module "vpc" {
  source  = "aws-ia/vpc/aws"
  version = ">= 1.0.0"

  name = local.vpc.name
  tags_prefix              = local.vpc.name
  cidr_block               = "${local.vpc.cidr_prefix}.0.0/16"
  az_count                 = length(data.aws_availability_zones.available.names)
  vpc_enable_dns_hostnames = true
...
```