### PR TITLE
document tf common error

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -173,6 +173,29 @@ If you're building VPCs using AWS IP Address Manager, this module can help you w
 
 You can use this module to build multiple IPAM VPCs but they must be created in manual sequence (`-target`).
 
+# Common Errors and their Fixes
+
+## Resource Not Found
+
+Error:
+
+> Warning: AWS Resource Not Found
+
+Because this module uses 2 providers, `aws` and `awscc`, if your `AWS_DEFAULT_REGION` environment varaible is different than what is hard-coded in your HCL, the AWSCC provider will use the default region. This will result in no ability to find the resources with a hardcoded region. You can fix this by hardcoding a region for both environments or updating your environment variable:
+
+```terraform
+provider "aws" {
+  region = <>
+}
+provider "awscc" {
+  region = <>
+}
+```
+
+or
+
+`export AWS_DEFAULT_REGION=<>`
+
 ## Contributing
 
 Please see our [developer documentation](https://github.com/aws-ia/terraform-aws-vpc/blob/main/contributing.md) for guidance on contributing to this module

--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ If you're building VPCs using AWS IP Address Manager, this module can help you w
 
 You can use this module to build multiple IPAM VPCs but they must be created in manual sequence (`-target`).
 
+# Common Errors and their Fixes
+
+## Resource Not Found
+
+Error:
+
+> Warning: AWS Resource Not Found
+
+Because this module uses 2 providers, `aws` and `awscc`, if your `AWS_DEFAULT_REGION` environment varaible is different than what is hard-coded in your HCL, the AWSCC provider will use the default region. This will result in no ability to find the resources with a hardcoded region. You can fix this by hardcoding a region for both environments or updating your environment variable:
+
+```terraform
+provider "aws" {
+  region = <>
+}
+provider "awscc" {
+  region = <>
+}
+```
+
+or
+
+`export AWS_DEFAULT_REGION=<>`
+
 ## Contributing
 
 Please see our [developer documentation](https://github.com/aws-ia/terraform-aws-vpc/blob/main/contributing.md) for guidance on contributing to this module


### PR DESCRIPTION
document common error that can happen when you override the environment aws region variable in only a single provider definition