### PR TITLE
Feature allow `connect_to_natgw` for secondary invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 | <a name="input_vpc_ipv4_ipam_pool_id"></a> [vpc\_ipv4\_ipam\_pool\_id](#input\_vpc\_ipv4\_ipam\_pool\_id) | Set to use IPAM to get CIDR block. | `string` | `null` | no |
 | <a name="input_vpc_ipv4_netmask_length"></a> [vpc\_ipv4\_netmask\_length](#input\_vpc\_ipv4\_netmask\_length) | Set to use IPAM to get CIDR block using a specified netmask. Must be set with var.vpc\_ipv4\_ipam\_pool\_id. | `string` | `null` | no |
 | <a name="input_vpc_secondary_cidr"></a> [vpc\_secondary\_cidr](#input\_vpc\_secondary\_cidr) | If `true` the module will create a `aws_vpc_ipv4_cidr_block_association` and subnets for that secondary cidr. If using IPAM for both primary and secondary CIDRs, you may only call this module serially (aka using `-target`, etc). | `bool` | `false` | no |
-| <a name="input_vpc_secondary_cidr_natgw"></a> [vpc\_secondary\_cidr\_natgw](#input\_vpc\_secondary\_cidr\_natgw) | n/a | `any` | `{}` | no |
+| <a name="input_vpc_secondary_cidr_natgw"></a> [vpc\_secondary\_cidr\_natgw](#input\_vpc\_secondary\_cidr\_natgw) | When invoking module for a secondary\_cidr attachment, you can map your private / tgw subnets to set of nat gateways by passing a map of az : { id: "nat-<id>"} | `any` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 | <a name="input_vpc_ipv4_ipam_pool_id"></a> [vpc\_ipv4\_ipam\_pool\_id](#input\_vpc\_ipv4\_ipam\_pool\_id) | Set to use IPAM to get CIDR block. | `string` | `null` | no |
 | <a name="input_vpc_ipv4_netmask_length"></a> [vpc\_ipv4\_netmask\_length](#input\_vpc\_ipv4\_netmask\_length) | Set to use IPAM to get CIDR block using a specified netmask. Must be set with var.vpc\_ipv4\_ipam\_pool\_id. | `string` | `null` | no |
 | <a name="input_vpc_secondary_cidr"></a> [vpc\_secondary\_cidr](#input\_vpc\_secondary\_cidr) | If `true` the module will create a `aws_vpc_ipv4_cidr_block_association` and subnets for that secondary cidr. If using IPAM for both primary and secondary CIDRs, you may only call this module serially (aka using `-target`, etc). | `bool` | `false` | no |
+| <a name="input_vpc_secondary_cidr_natgw"></a> [vpc\_secondary\_cidr\_natgw](#input\_vpc\_secondary\_cidr\_natgw) | n/a | `any` | `{}` | no |
 
 ## Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -44,6 +44,7 @@ locals {
   }
   # if public subnets being built, check how many nats to create
   # options defined by `local.nat_options`
+  # nat_configuration is a list of az names where a nat should be created
   nat_configuration = contains(local.subnet_keys, "public") ? local.nat_options[try(var.subnets.public.nat_gateway_configuration, "none")] : local.nat_options["none"]
 
   # used to reference which nat gateway id should be used in route

--- a/examples/secondary_cidr/README.md
+++ b/examples/secondary_cidr/README.md
@@ -15,22 +15,29 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_secondary"></a> [secondary](#module\_secondary) | ../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_natgw_id_1"></a> [natgw\_id\_1](#input\_natgw\_id\_1) | nat gw id for az 2 | `string` | n/a | yes |
+| <a name="input_natgw_id_2"></a> [natgw\_id\_2](#input\_natgw\_id\_2) | nat gw id for az 2 | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | vpc id to create secondary cidr on | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/secondary_cidr/README.md
+++ b/examples/secondary_cidr/README.md
@@ -21,7 +21,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_secondary"></a> [secondary](#module\_secondary) | aws-ia/vpc/aws | >= 2.0.0 |
+| <a name="module_secondary"></a> [secondary](#module\_secondary) | ../.. | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
 
 ## Resources
 
@@ -33,8 +34,5 @@ No inputs.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Map of private subnet attributes grouped by az. |
-| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Map of public subnet attributes grouped by az. |
+No outputs.
 <!-- END_TF_DOCS -->

--- a/examples/secondary_cidr/README.md
+++ b/examples/secondary_cidr/README.md
@@ -23,7 +23,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_secondary"></a> [secondary](#module\_secondary) | ../.. | n/a |
+| <a name="module_secondary"></a> [secondary](#module\_secondary) | aws-ia/vpc/aws | >= 2.0.0 |
 
 ## Resources
 

--- a/examples/secondary_cidr/main.tf
+++ b/examples/secondary_cidr/main.tf
@@ -1,9 +1,8 @@
 data "aws_region" "current" {}
 
 module "secondary" {
-  # source  = "aws-ia/vpc/aws"
-  # version = ">= 2.0.0"
-  source = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 2.0.0"
 
   name       = "secondary-cidr"
   az_count   = 2

--- a/examples/secondary_cidr/main.tf
+++ b/examples/secondary_cidr/main.tf
@@ -1,35 +1,46 @@
 # To test this example, uncomment the module blocks for "vpc" and "ipam_base_for_example_only"
 
 module "secondary" {
-  source  = "aws-ia/vpc/aws"
-  version = ">= 2.0.0"
+  # source  = "aws-ia/vpc/aws"
+  # version = ">= 2.0.0"
+  source = "../.."
 
-  name = "secondary-cidr"
+  name       = "secondary-cidr"
+  cidr_block = "10.2.0.0/16"
 
-  vpc_secondary_cidr      = true
-  vpc_id                  = module.vpc.vpc.id
-  vpc_ipv4_ipam_pool_id   = module.ipam_base_for_example_only.pool_id
-  vpc_ipv4_netmask_length = 20
-  az_count                = 2
+  vpc_secondary_cidr = true
+  vpc_id             = module.vpc.vpc_attributes.id
+
+  vpc_secondary_cidr_natgw = module.vpc.nat_gateway_attributes_by_az
+  az_count                 = 2
 
   subnets = {
-    private = { netmask = 24 }
+    private = {
+      name_prefix             = "secondary-private-natgw-connected"
+      netmask                 = 18
+      connect_to_public_natgw = true
+    }
   }
 }
 
-# module "ipam_base_for_example_only" {
-#   source = "../../test/hcl_fixtures/ipam_base"
-# }
+module "vpc" {
+  # source  = "aws-ia/vpc/aws"
+  # version = ">= 2.0.0"
+  source = "../.."
 
-# module "vpc" {
-#   source  = "aws-ia/vpc/aws"
-#   version = ">= 1.0.0"
+  name       = "primary-az-vpc"
+  cidr_block = "10.0.0.0/16"
+  az_count   = 3
 
-#   name       = "multi-az-vpc"
-#   cidr_block = "10.0.0.0/16"
-#   az_count   = 3
-
-#   subnets = {
-#     private = { netmask = 24 }
-#   }
-# }
+  subnets = {
+    public = {
+      name_prefix               = "primary-vpc-public" # omit to prefix with "public"
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs" # options: "single_az", "none"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+}

--- a/examples/secondary_cidr/outputs.tf
+++ b/examples/secondary_cidr/outputs.tf
@@ -1,9 +1,9 @@
-output "public_subnets" {
-  description = "Map of public subnet attributes grouped by az."
-  value       = module.secondary.public_subnet_cidrs_by_az
-}
+# output "public_subnets" {
+#   description = "Map of public subnet attributes grouped by az."
+#   value       = module.secondary.public_subnet_attributes_by_az
+# }
 
-output "private_subnets" {
-  description = "Map of private subnet attributes grouped by az."
-  value       = module.secondary.private_subnet_attributes_by_az
-}
+# output "private_subnets" {
+#   description = "Map of private subnet attributes grouped by az."
+#   value       = module.secondary.private_subnet_attributes_by_az
+# }

--- a/examples/secondary_cidr/variables.tf
+++ b/examples/secondary_cidr/variables.tf
@@ -1,0 +1,14 @@
+variable "vpc_id" {
+  description = "vpc id to create secondary cidr on"
+  type        = string
+}
+
+variable "natgw_id_1" {
+  description = "nat gw id for az 2"
+  type        = string
+}
+
+variable "natgw_id_2" {
+  description = "nat gw id for az 2"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,8 @@ resource "aws_route" "private_to_nat" {
   route_table_id         = awscc_ec2_route_table.private[each.key].id
   destination_cidr_block = "0.0.0.0/0"
   # try to get nat for AZ, else use singular nat
-  nat_gateway_id = try(aws_nat_gateway.main[split("/", each.key)[1]].id, aws_nat_gateway.main[local.nat_configuration[0]].id)
+  nat_gateway_id = local.nat_per_az[split("/", each.key)[1]].id
+  //try(aws_nat_gateway.main[split("/", each.key)[1]].id, aws_nat_gateway.main[local.nat_configuration[0]].id)
 }
 
 resource "aws_route" "private_to_tgw" {
@@ -225,7 +226,8 @@ resource "aws_route" "tgw_to_nat" {
   route_table_id         = awscc_ec2_route_table.tgw[each.key].id
   destination_cidr_block = "0.0.0.0/0"
   # try to get nat for AZ, else use singular nat
-  nat_gateway_id = try(aws_nat_gateway.main[each.key].id, aws_nat_gateway.main[local.nat_configuration[0]].id)
+  nat_gateway_id = local.nat_per_az[each.key].id
+  //try(aws_nat_gateway.main[each.key].id, aws_nat_gateway.main[local.nat_configuration[0]].id)
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "tgw" {

--- a/test/examples_secondary_cidr_test.go
+++ b/test/examples_secondary_cidr_test.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestExamplesSecondaryCidr(t *testing.T) {
+
+	primary := &terraform.Options{
+		TerraformDir: "./hcl_fixtures/secondary_cidr_base",
+	}
+	defer terraform.Destroy(t, primary)
+	terraform.InitAndApply(t, primary)
+
+	// region := terraform.Output(t, primary, "region")
+	vpcId := terraform.Output(t, primary, "vpc_id")
+	natgwId1 := terraform.Output(t, primary, "natgw_id_1")
+	natgwId2 := terraform.Output(t, primary, "natgw_id_2")
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/secondary_cidr",
+		Vars: map[string]interface{}{
+			"vpc_id":     vpcId,
+			"natgw_id_1": natgwId1,
+			"natgw_id_2": natgwId2,
+			// "natgw_attrs": map[string]interface{}{
+			// 	fmt.Sprintf("%v%v", region, "a"): natgwId1,
+			// 	fmt.Sprintf("%v%v", region, "b"): natgwId2,
+			// },
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+}

--- a/test/hcl_fixtures/secondary_cidr_base/main.tf
+++ b/test/hcl_fixtures/secondary_cidr_base/main.tf
@@ -1,9 +1,8 @@
 data "aws_availability_zones" "current" {}
 
 module "vpc" {
-  source = "../../.."
-  #   source  = "aws-ia/vpc/aws"
-  # version = ">= 2.0.0"
+  source  = "aws-ia/vpc/aws"
+  version = ">= 2.0.0"
 
   name       = "primary-az-vpc"
   cidr_block = "10.0.0.0/16"

--- a/test/hcl_fixtures/secondary_cidr_base/main.tf
+++ b/test/hcl_fixtures/secondary_cidr_base/main.tf
@@ -1,0 +1,23 @@
+data "aws_availability_zones" "current" {}
+
+module "vpc" {
+  source = "../../.."
+  #   source  = "aws-ia/vpc/aws"
+  # version = ">= 2.0.0"
+
+  name       = "primary-az-vpc"
+  cidr_block = "10.0.0.0/16"
+  az_count   = 2
+
+  subnets = {
+    public = {
+      name_prefix               = "primary-vpc-public" # omit to prefix with "public"
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs" # options: "single_az", "none"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+}

--- a/test/hcl_fixtures/secondary_cidr_base/outputs.tf
+++ b/test/hcl_fixtures/secondary_cidr_base/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  description = "vpc id"
+  value       = module.vpc.vpc_attributes.id
+
+}
+
+output "natgw_id_1" {
+  value       = module.vpc.nat_gateway_attributes_by_az[data.aws_availability_zones.current.names[0]].id
+  description = "nat gateway attributes"
+}
+
+output "natgw_id_2" {
+  value       = module.vpc.nat_gateway_attributes_by_az[data.aws_availability_zones.current.names[1]].id
+  description = "nat gateway attributes"
+}

--- a/test/hcl_fixtures/secondary_cidr_base/providers.tf
+++ b/test/hcl_fixtures/secondary_cidr_base/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.0.7"
+  experiments      = [module_variable_optional_attrs]
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72.0"
+    }
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "vpc_secondary_cidr" {
   default     = false
 }
 
+variable "vpc_secondary_cidr_natgw" {
+  type        = any
+  description = ""
+  default     = {}
+}
+
 variable "vpc_enable_dns_support" {
   type        = bool
   description = "Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range \"plus two\" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default."

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "vpc_secondary_cidr" {
 
 variable "vpc_secondary_cidr_natgw" {
   type        = any
-  description = ""
+  description = "When invoking module for a secondary_cidr attachment, you can map your private / tgw subnets to set of nat gateways by passing a map of az : { id: \"nat-<id>\"}"
   default     = {}
 }
 


### PR DESCRIPTION
Closes: #79 

```shell
TestExamplesSecondaryCidr 2022-08-17T14:46:47-04:00 logger.go:66: 
PASS
ok      github.com/aws-ia/terraform-aws-vpc     475.711s
```

```shell
TestExamplesPublicPrivate 2022-08-17T14:52:51-04:00 logger.go:66: 
PASS
ok      github.com/aws-ia/terraform-aws-vpc     227.595s
```

```shell
TestExamplesTransitGateway 2022-08-17T15:01:01-04:00 logger.go:66: 
PASS
ok      github.com/aws-ia/terraform-aws-vpc     470.378s
```