### PR TITLE
add s3 option for vpc flow logs

### DIFF
--- a/defaults.tf
+++ b/defaults.tf
@@ -12,9 +12,9 @@ locals {
 
     # sensiblie defaults that can all be overridden
     log_destination_type = var.vpc_flow_logs.log_destination_type == null ? "cloud-watch-logs" : var.vpc_flow_logs.log_destination_type
-    retention_in_days    = var.vpc_flow_logs.retention_in_days == null ? 180 : var.vpc_flow_logs.retention_in_days
+    retention_in_days    = try(var.vpc_flow_logs.retention_in_days, null)
     traffic_type         = var.vpc_flow_logs.traffic_type == null ? "ALL" : var.vpc_flow_logs.traffic_type
-    destination_options = var.vpc_flow_logs.destination_options == null ? {
+    destination_options = can(var.vpc_flow_logs.destination_options) ? {
       file_format                = "plain-text"
       hive_compatible_partitions = false
       per_hour_partition         = false

--- a/examples/public_private_flow_logs/README.md
+++ b/examples/public_private_flow_logs/README.md
@@ -22,7 +22,7 @@ At this point, only cloud-watch logs are support, pending: https://github.com/aw
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 2.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
 
 ## Resources
 
@@ -35,7 +35,7 @@ At this point, only cloud-watch logs are support, pending: https://github.com/aw
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS Key ID | `string` | `null` | no |
-| <a name="input_vpc_flow_logs"></a> [vpc\_flow\_logs](#input\_vpc\_flow\_logs) | Whether or not to create VPC flow logs and which type. Options: "cloudwatch", "s3", "none". | <pre>object({<br>    log_destination = optional(string)<br>    iam_role_arn    = optional(string)<br>    kms_key_id      = optional(string)<br><br>    log_destination_type = string<br>    retention_in_days    = optional(number)<br>    tags                 = optional(map(string))<br>    traffic_type         = optional(string)<br>    destination_options = optional(object({<br>      file_format                = optional(string)<br>      hive_compatible_partitions = optional(bool)<br>      per_hour_partition         = optional(bool)<br>    }))<br>  })</pre> | <pre>{<br>  "kms_key_id": null,<br>  "log_destination_type": "s3",<br>  "retention_in_days": null<br>}</pre> | no |
+| <a name="input_vpc_flow_logs"></a> [vpc\_flow\_logs](#input\_vpc\_flow\_logs) | Whether or not to create VPC flow logs and which type. Options: "cloudwatch", "s3", "none". | <pre>object({<br>    log_destination = optional(string)<br>    iam_role_arn    = optional(string)<br>    kms_key_id      = optional(string)<br><br>    log_destination_type = string<br>    retention_in_days    = optional(number)<br>    tags                 = optional(map(string))<br>    traffic_type         = optional(string)<br>    destination_options = optional(object({<br>      file_format                = optional(string)<br>      hive_compatible_partitions = optional(bool)<br>      per_hour_partition         = optional(bool)<br>    }))<br>  })</pre> | <pre>{<br>  "kms_key_id": null,<br>  "log_destination_type": "cloud-watch-logs",<br>  "retention_in_days": 180<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/public_private_flow_logs/README.md
+++ b/examples/public_private_flow_logs/README.md
@@ -7,19 +7,22 @@ At this point, only cloud-watch logs are support, pending: https://github.com/aw
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 2.0.0 |
 
 ## Resources
 
@@ -32,6 +35,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS Key ID | `string` | `null` | no |
+| <a name="input_vpc_flow_logs"></a> [vpc\_flow\_logs](#input\_vpc\_flow\_logs) | Whether or not to create VPC flow logs and which type. Options: "cloudwatch", "s3", "none". | <pre>object({<br>    log_destination = optional(string)<br>    iam_role_arn    = optional(string)<br>    kms_key_id      = optional(string)<br><br>    log_destination_type = string<br>    retention_in_days    = optional(number)<br>    tags                 = optional(map(string))<br>    traffic_type         = optional(string)<br>    destination_options = optional(object({<br>      file_format                = optional(string)<br>      hive_compatible_partitions = optional(bool)<br>      per_hour_partition         = optional(bool)<br>    }))<br>  })</pre> | <pre>{<br>  "kms_key_id": null,<br>  "log_destination_type": "s3",<br>  "retention_in_days": null<br>}</pre> | no |
 
 ## Outputs
 

--- a/examples/public_private_flow_logs/main.tf
+++ b/examples/public_private_flow_logs/main.tf
@@ -4,7 +4,7 @@ module "vpc" {
   source  = "aws-ia/vpc/aws"
   version = ">= 2.0.0"
 
-  name       = "tag-test"
+  name       = "public-private-flowlogs"
   cidr_block = "10.0.0.0/20"
   az_count   = 2
 
@@ -26,11 +26,7 @@ module "vpc" {
     }
   }
 
-  vpc_flow_logs = {
-    log_destination_type = "cloud-watch-logs"
-    retention_in_days    = 180
-    kms_key_id           = var.kms_key_id
-  }
+  vpc_flow_logs = var.vpc_flow_logs
 
   tags = {
     "key" = "value"

--- a/examples/public_private_flow_logs/outputs.tf
+++ b/examples/public_private_flow_logs/outputs.tf
@@ -3,6 +3,13 @@ output "public_subnets" {
   value       = module.vpc.public_subnet_attributes_by_az
 }
 
+output "private_subnets" {
+  description = "Map of private subnet attributes grouped by az."
+  value       = module.vpc.private_subnet_attributes_by_az
+}
+
+## Used for Testing, do not delete
+
 output "public_subnets_tags_length" {
   description = "Count of public subnet tags for a single az."
   value       = length(module.vpc.public_subnet_attributes_by_az[data.aws_availability_zones.current.names[0]].tags)
@@ -11,9 +18,4 @@ output "public_subnets_tags_length" {
 output "private_subnets_tags_length" {
   description = "Count of private subnet tags for a single az."
   value       = length(module.vpc.private_subnet_attributes_by_az["private/${data.aws_availability_zones.current.names[0]}"].tags)
-}
-
-output "private_subnets" {
-  description = "Map of private subnet attributes grouped by az."
-  value       = module.vpc.private_subnet_attributes_by_az
 }

--- a/examples/public_private_flow_logs/providers.tf
+++ b/examples/public_private_flow_logs/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15.0"
+  experiments      = [module_variable_optional_attrs]
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.73.0"
+    }
+  }
+}

--- a/examples/public_private_flow_logs/variables.tf
+++ b/examples/public_private_flow_logs/variables.tf
@@ -3,3 +3,28 @@ variable "kms_key_id" {
   type        = string
   default     = null
 }
+
+variable "vpc_flow_logs" {
+  description = "Whether or not to create VPC flow logs and which type. Options: \"cloudwatch\", \"s3\", \"none\"."
+
+  type = object({
+    log_destination = optional(string)
+    iam_role_arn    = optional(string)
+    kms_key_id      = optional(string)
+
+    log_destination_type = string
+    retention_in_days    = optional(number)
+    tags                 = optional(map(string))
+    traffic_type         = optional(string)
+    destination_options = optional(object({
+      file_format                = optional(string)
+      hive_compatible_partitions = optional(bool)
+      per_hour_partition         = optional(bool)
+    }))
+  })
+  default = {
+    log_destination_type = "s3"
+    retention_in_days    = null
+    kms_key_id           = null
+  }
+}

--- a/examples/public_private_flow_logs/variables.tf
+++ b/examples/public_private_flow_logs/variables.tf
@@ -23,8 +23,8 @@ variable "vpc_flow_logs" {
     }))
   })
   default = {
-    log_destination_type = "s3"
-    retention_in_days    = null
+    log_destination_type = "cloud-watch-logs"
+    retention_in_days    = 180
     kms_key_id           = null
   }
 }

--- a/examples/transit_gateway/outputs.tf
+++ b/examples/transit_gateway/outputs.tf
@@ -1,3 +1,5 @@
+## Used for Testing, do not delete
+
 output "tgw_subnets_tags_length" {
   description = "Count of tgw subnet tags for a single az."
   value       = length(module.vpc.tgw_subnet_attributes_by_az[data.aws_availability_zones.current.names[0]].tags)

--- a/modules/flow_logs/modules/s3_log_bucket/main.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/main.tf
@@ -1,0 +1,44 @@
+#tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
+resource "aws_s3_bucket" "flow_logs" {
+  bucket_prefix = "vpc-flow-logs-${var.name}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+#tfsec:ignore:aws-s3-encryption-customer-key
+resource "aws_s3_bucket_server_side_encryption_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.bucket
+
+  rule {
+    id = "transition"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    expiration {
+      days = 60
+    }
+
+    status = "Enabled"
+  }
+}

--- a/modules/flow_logs/modules/s3_log_bucket/outputs.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket_flow_logs_attributes" {
+  value = aws_s3_bucket.flow_logs
+}

--- a/modules/flow_logs/modules/s3_log_bucket/providers.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72.0"
+    }
+  }
+}

--- a/modules/flow_logs/modules/s3_log_bucket/variables.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  type        = string
+  description = "(optional) describe your variable"
+}

--- a/test/examples_public_private_test.go
+++ b/test/examples_public_private_test.go
@@ -22,3 +22,23 @@ func TestExamplesPublicPrivate(t *testing.T) {
 	privateTagsLength := terraform.Output(t, terraformOptions, "private_subnets_tags_length")
 	assert.Equal(t, "2", privateTagsLength)
 }
+
+func TestExamplesPublicPrivateS3FlowLogs(t *testing.T) {
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/public_private_flow_logs",
+		Vars: map[string]interface{}{
+			"vpc_flow_logs": map[string]interface{}{
+				"log_destination_type": "s3",
+				"kms_key_id":           nil,
+				"desination_options": map[string]interface{}{
+					"file_format": "parquet",
+				},
+			},
+		},
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+}

--- a/test/examples_public_private_test.go
+++ b/test/examples_public_private_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/likexian/gokit/assert"
 )
 
-func TestExamplesPublicPrivate(t *testing.T) {
+func TestExamplesPublicPrivateCWLogs(t *testing.T) {
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/public_private_flow_logs",


### PR DESCRIPTION
add support for vpc flow logs to s3. can create an s3 bucket if arn is not provided

```shell
$ go test -run TestExamplesPublicPrivate -timeout 45m
TestExamplesPublicPrivateS3FlowLogs 2022-08-19T14:26:33-04:00 logger.go:66: 
PASS
ok      github.com/aws-ia/terraform-aws-vpc     510.122s

TestExamplesPublicPrivateCWLogs 2022-08-19T15:08:12-04:00 logger.go:66: 
PASS
ok      github.com/aws-ia/terraform-aws-vpc     285.715s
```