### PR TITLE
Adding Cloud WAN support

### DIFF
--- a/.header.md
+++ b/.header.md
@@ -41,7 +41,7 @@ module "vpc" {
 
 ## Reserved Subnet Key Names
 
-There are 3 reserved keys for subnet key names in var.subnets corresponding to types "public", "transit_gateway", and "core_network". Other custom subnet key names are valid are and those subnets will be private subnets.
+There are 3 reserved keys for subnet key names in var.subnets corresponding to types "public", "transit_gateway", and "core_network" [(an AWS Cloud WAN feature)](https://docs.aws.amazon.com/vpc/latest/cloudwan/cloudwan-networks-working-with.html). Other custom subnet key names are valid are and those subnets will be private subnets.
 
 ```terraform
 transit_gateway_id = <>

--- a/.header.md
+++ b/.header.md
@@ -41,7 +41,7 @@ module "vpc" {
 
 ## Reserved Subnet Key Names
 
-There are 2 reserved keys for subnet key names in var.subnets corresponding to types "public" and "transit_gateway". Other custom subnet key names are valid are and those subnets will be private subnets.
+There are 3 reserved keys for subnet key names in var.subnets corresponding to types "public", "transit_gateway", and "core_network". Other custom subnet key names are valid are and those subnets will be private subnets.
 
 ```terraform
 transit_gateway_id = <>
@@ -82,6 +82,33 @@ subnets = {
 
     tags = {
       subnet_type = "tgw"
+    }
+}
+```
+
+```terraform
+core_network = {
+  id  = <>
+  arn = <>
+}
+core_network_routes = {
+  workload = "pl-123"
+}
+
+subnets = {
+  workload = {
+    name_prefix = "workload-private"
+    netmask     = 24
+  }
+
+  core_network = {
+    netmask            = 28
+    ipv6_support       = false
+    require_acceptance = true
+    accept_attachment  = true
+
+    tags = {
+      env = "prod"
     }
 }
 ```
@@ -207,6 +234,51 @@ or
 
 `export AWS_DEFAULT_REGION=<>`
 
-## Contributing
+## Error creating routes to Core Network
+
+Error:
+
+> error creating Route in Route Table (rtb-xxx) with destination (YYY): InvalidCoreNetworkArn.NotFound: The core network arn 'arn:aws:networkmanager::XXXX:core-network/core-network-YYYYY' does not exist.
+
+This happens when the Core Network's VPC attachment requires acceptance, so it's not possible to create the routes in the VPC until the attachment is accepted. Check the following:
+
+* If the VPC attachment requires acceptance and you want the module to automatically accept it, configure `require_acceptance` and `accept_attachment` to `true`.
+
+```terraform
+subnets = {
+  core_network = {
+    netmaks            = 28
+    require_acceptance = true
+    accept_attachment  = true
+  }
+}
+```
+
+* If the VPC attachment requires acceptance but you want to accept it outside the module, first configure `require_acceptance` to `true` and `accept_attachment` to `false`.
+
+```terraform
+subnets = {
+  core_network = {
+    netmaks            = 28
+    require_acceptance = true
+    accept_attachment  = true
+  }
+}
+```
+
+After you apply and the attachment is accepted (outside the module), change the subnet configuration with `require_acceptance` to `false`.
+
+```terraform
+subnets = {
+  core_network = {
+    netmaks            = 28
+    require_acceptance = false
+  }
+}
+```
+
+* Alternatively, you can also not configure any subnet route (`var.core_network_routes`) to the Core Network until the attachment gets accepted.
+
+# Contributing
 
 Please see our [developer documentation](https://github.com/aws-ia/terraform-aws-vpc/blob/main/contributing.md) for guidance on contributing to this module

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "vpc" {
 
 ## Reserved Subnet Key Names
 
-There are 3 reserved keys for subnet key names in var.subnets corresponding to types "public", "transit\_gateway", and "core\_network". Other custom subnet key names are valid are and those subnets will be private subnets.
+There are 3 reserved keys for subnet key names in var.subnets corresponding to types "public", "transit\_gateway", and "core\_network" [(an AWS Cloud WAN feature)](https://docs.aws.amazon.com/vpc/latest/cloudwan/cloudwan-networks-working-with.html). Other custom subnet key names are valid are and those subnets will be private subnets.
 
 ```terraform
 transit_gateway_id = <>

--- a/README.md
+++ b/README.md
@@ -290,14 +290,14 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | = 0.33.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
-| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | = 0.33.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | >= 0.36.0 |
 
 ## Modules
 
@@ -333,16 +333,16 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 | [aws_subnet.tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_ipv4_cidr_block_association.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv4_cidr_block_association) | resource |
-| [awscc_ec2_route_table.cwan](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.private](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.public](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.tgw](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_subnet_route_table_association.cwan](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.private](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.public](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.tgw](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_route_table.cwan](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.private](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.public](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.tgw](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_subnet_route_table_association.cwan](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.private](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.public](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.tgw](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
 | [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [awscc_ec2_vpc.main](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/data-sources/ec2_vpc) | data source |
+| [awscc_ec2_vpc.main](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/data-sources/ec2_vpc) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -290,14 +290,14 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.15.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | = 0.33.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
-| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | >= 0.15.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | = 0.33.0 |
 
 ## Modules
 
@@ -333,16 +333,16 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 | [aws_subnet.tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_ipv4_cidr_block_association.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv4_cidr_block_association) | resource |
-| [awscc_ec2_route_table.cwan](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.private](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.public](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_route_table.tgw](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_route_table) | resource |
-| [awscc_ec2_subnet_route_table_association.cwan](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.private](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.public](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
-| [awscc_ec2_subnet_route_table_association.tgw](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_route_table.cwan](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.private](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.public](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_route_table.tgw](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_route_table) | resource |
+| [awscc_ec2_subnet_route_table_association.cwan](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.private](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.public](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
+| [awscc_ec2_subnet_route_table_association.tgw](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/ec2_subnet_route_table_association) | resource |
 | [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [awscc_ec2_vpc.main](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/data-sources/ec2_vpc) | data source |
+| [awscc_ec2_vpc.main](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/data-sources/ec2_vpc) | data source |
 
 ## Inputs
 

--- a/data.tf
+++ b/data.tf
@@ -19,7 +19,7 @@ locals {
   # - subnets map contains arbitrary amount of subnet "keys" which are both defined as the subnets type and default name (unless name_prefix is provided).
   # - resource name labels for subnet use the key as  private subnet keys are constructed
 
-  singleton_subnet_types = ["public", "transit_gateway"]
+  singleton_subnet_types = ["public", "transit_gateway", "core_network"]
   private_subnet_names   = setsubtract(local.subnet_keys, local.singleton_subnet_types)
 
   # constructed list of <private_subnet_key>/az
@@ -34,6 +34,14 @@ locals {
   #private_subnet_key_names_tgw_routed = [for subnet in local.private_per_az : subnet if contains(local.private_subnets_tgw_routed, split("/", subnet)[0])]
   subnets_tgw_routed                  = keys(var.transit_gateway_routes)
   private_subnet_key_names_tgw_routed = [for subnet in local.private_per_az : subnet if contains(local.subnets_tgw_routed, split("/", subnet)[0])]
+
+  # support variables for core_network_routes
+  subnets_cwan_routed                  = keys(var.core_network_routes)
+  private_subnet_key_names_cwan_routes = [for subnet in local.private_per_az : subnet if contains(local.subnets_cwan_routed, split("/", subnet)[0])]
+  require_acceptance                   = try(var.subnets.core_network.require_acceptance, false) # value to default
+  accept_attachment                    = try(var.subnets.core_network.accept_attachment, true)   # value to default
+  create_acceptance                    = (local.require_acceptance == true && local.accept_attachment == true)
+  create_cwan_routes                   = (local.require_acceptance == false) || local.create_acceptance
 
   ##################################################################
   # NAT configurations options, maps user string input to HCL usable values. selected based on nat_gateway_configuration

--- a/examples/cloud_wan/.header.md
+++ b/examples/cloud_wan/.header.md
@@ -1,0 +1,10 @@
+# Creating AWS Cloud WAN's VPC attachment
+
+This example shows how you can use this module with `core_network` subnets, and AWS Cloud WAN's VPC attachment. This examples creates the following:
+
+* Global Network and Core Network.
+* Core Network's policy (in `cwan_policy.tf`), creating two segments (prod and nonprod) in two AWS Regions (*us-east-1* and *eu-west-1*). The *prod* segments needs acceptance for the attachments.
+* The VPC module creates the following (in two AWS Regions):
+  * Two sets of subnets (workloads and core_network)
+  * Cloud WAN's VPC attachment - with attachment acceptance for the VPC to associate to the *prod* segment.
+  * Routing to Core Network (0.0.0.0/0) in workload subnets.

--- a/examples/cloud_wan/.terraform-docs.yaml
+++ b/examples/cloud_wan/.terraform-docs.yaml
@@ -1,0 +1,21 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+  lockfile: false
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/cloud_wan/README.md
+++ b/examples/cloud_wan/README.md
@@ -16,28 +16,28 @@ This example shows how you can use this module with `core_network` subnets, and 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | = 0.33.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.36.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27.0 |
-| <a name="provider_awscc.awsccnvirginia"></a> [awscc.awsccnvirginia](#provider\_awscc.awsccnvirginia) | = 0.33.0 |
+| <a name="provider_awscc.awsccnvirginia"></a> [awscc.awsccnvirginia](#provider\_awscc.awsccnvirginia) | >= 0.36.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | ../.. | n/a |
-| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | ../.. | n/a |
+| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | aws-ia/vpc/aws | >= 3.0.2 |
+| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | aws-ia/vpc/aws | >= 3.0.2 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [awscc_networkmanager_core_network.core_network](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/networkmanager_core_network) | resource |
-| [awscc_networkmanager_global_network.global_network](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/networkmanager_global_network) | resource |
+| [awscc_networkmanager_core_network.core_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_core_network) | resource |
+| [awscc_networkmanager_global_network.global_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_global_network) | resource |
 | [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
 
 ## Inputs

--- a/examples/cloud_wan/README.md
+++ b/examples/cloud_wan/README.md
@@ -16,14 +16,14 @@ This example shows how you can use this module with `core_network` subnets, and 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.25.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | = 0.33.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27.0 |
-| <a name="provider_awscc.awsccnvirginia"></a> [awscc.awsccnvirginia](#provider\_awscc.awsccnvirginia) | >= 0.25.0 |
+| <a name="provider_awscc.awsccnvirginia"></a> [awscc.awsccnvirginia](#provider\_awscc.awsccnvirginia) | = 0.33.0 |
 
 ## Modules
 
@@ -36,8 +36,8 @@ This example shows how you can use this module with `core_network` subnets, and 
 
 | Name | Type |
 |------|------|
-| [awscc_networkmanager_core_network.core_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_core_network) | resource |
-| [awscc_networkmanager_global_network.global_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_global_network) | resource |
+| [awscc_networkmanager_core_network.core_network](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/networkmanager_core_network) | resource |
+| [awscc_networkmanager_global_network.global_network](https://registry.terraform.io/providers/hashicorp/awscc/0.33.0/docs/resources/networkmanager_global_network) | resource |
 | [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
 
 ## Inputs

--- a/examples/cloud_wan/README.md
+++ b/examples/cloud_wan/README.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_TF_DOCS -->
+# Creating AWS Cloud WAN's VPC attachment
+
+This example shows how you can use this module with `core_network` subnets, and AWS Cloud WAN's VPC attachment. This examples creates the following:
+
+* Global Network and Core Network.
+* Core Network's policy (in `cwan_policy.tf`), creating two segments (prod and nonprod) in two AWS Regions (*us-east-1* and *eu-west-1*). The *prod* segments needs acceptance for the attachments.
+* The VPC module creates the following (in two AWS Regions):
+  * Two sets of subnets (workloads and core\_network)
+  * Cloud WAN's VPC attachment - with attachment acceptance for the VPC to associate to the *prod* segment.
+  * Routing to Core Network (0.0.0.0/0) in workload subnets.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.27.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.25.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27.0 |
+| <a name="provider_awscc.awsccnvirginia"></a> [awscc.awsccnvirginia](#provider\_awscc.awsccnvirginia) | >= 0.25.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | ../.. | n/a |
+| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [awscc_networkmanager_core_network.core_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_core_network) | resource |
+| [awscc_networkmanager_global_network.global_network](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/networkmanager_global_network) | resource |
+| [aws_networkmanager_core_network_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkmanager_core_network_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_wan_regions"></a> [cloud\_wan\_regions](#input\_cloud\_wan\_regions) | AWS Regions to create in Cloud WAN's core network. | <pre>object({<br>    nvirginia = string<br>    ireland   = string<br>  })</pre> | <pre>{<br>  "ireland": "eu-west-1",<br>  "nvirginia": "us-east-1"<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_core_network"></a> [core\_network](#output\_core\_network) | Core Network ID. |
+| <a name="output_core_network_vpc_attachments"></a> [core\_network\_vpc\_attachments](#output\_core\_network\_vpc\_attachments) | Core Network VPC attachments. |
+| <a name="output_global_network"></a> [global\_network](#output\_global\_network) | Global Network ID. |
+| <a name="output_vpcs"></a> [vpcs](#output\_vpcs) | VPCs created. |
+<!-- END_TF_DOCS -->

--- a/examples/cloud_wan/cwan_policy.tf
+++ b/examples/cloud_wan/cwan_policy.tf
@@ -1,0 +1,63 @@
+
+data "aws_networkmanager_core_network_policy_document" "policy" {
+  core_network_configuration {
+    vpn_ecmp_support = true
+    asn_ranges       = ["64515-64520"]
+
+    edge_locations {
+      location = var.cloud_wan_regions.nvirginia
+      asn      = 64515
+    }
+
+    edge_locations {
+      location = var.cloud_wan_regions.ireland
+      asn      = 64516
+    }
+  }
+
+  segments {
+    name                          = "prod"
+    description                   = "Segment for production traffic"
+    require_attachment_acceptance = true
+  }
+
+  segments {
+    name                          = "nonprod"
+    description                   = "Segment for non-production traffic"
+    require_attachment_acceptance = false
+  }
+
+  attachment_policies {
+    rule_number     = 100
+    condition_logic = "or"
+
+    conditions {
+      type     = "tag-value"
+      operator = "equals"
+      key      = "env"
+      value    = "prod"
+    }
+
+    action {
+      association_method = "constant"
+      segment            = "prod"
+    }
+  }
+
+  attachment_policies {
+    rule_number     = 200
+    condition_logic = "or"
+
+    conditions {
+      type     = "tag-value"
+      operator = "equals"
+      key      = "env"
+      value    = "nonprod"
+    }
+
+    action {
+      association_method = "constant"
+      segment            = "nonprod"
+    }
+  }
+}

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,9 +1,9 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.2"
-
+  #source  = "aws-ia/vpc/aws"
+  #version = ">= 3.0.2"
+  source = "../.."
   providers = {
     aws   = aws.awsnvirginia
     awscc = awscc.awsccnvirginia
@@ -38,9 +38,9 @@ module "nvirginia_vpc" {
 
 # VPC module (Ireland)
 module "ireland_vpc" {
-  source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.2"
-
+  #source  = "aws-ia/vpc/aws"
+  #version = ">= 3.0.2"
+  source = "../.."
   providers = {
     aws   = aws.awsireland
     awscc = awscc.awsccireland

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,9 +1,9 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  # source  = "aws-ia/vpc/aws"
-  # version = ">= 3.0.2"
-  source = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 3.0.2"
+
   providers = {
     aws   = aws.awsnvirginia
     awscc = awscc.awsccnvirginia
@@ -38,9 +38,9 @@ module "nvirginia_vpc" {
 
 # VPC module (Ireland)
 module "ireland_vpc" {
-  #source  = "aws-ia/vpc/aws"
-  #version = ">= 3.0.2"
-  source = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 3.0.2"
+
   providers = {
     aws   = aws.awsireland
     awscc = awscc.awsccireland

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,0 +1,99 @@
+
+# VPC module (North Virginia)
+module "nvirginia_vpc" {
+  source  = "aws-ia/vpc/aws"
+  version = ">= 3.0.2"
+
+  providers = {
+    aws   = aws.awsnvirginia
+    awscc = awscc.awsccnvirginia
+  }
+
+  name       = "nvirginia-vpc"
+  cidr_block = "10.0.0.0/24"
+  az_count   = 2
+
+  core_network = {
+    id  = awscc_networkmanager_core_network.core_network.core_network_id
+    arn = awscc_networkmanager_core_network.core_network.core_network_arn
+  }
+  core_network_routes = {
+    workload = "0.0.0.0/0"
+  }
+
+  subnets = {
+    workload = { netmask = 28 }
+    core_network = {
+      netmask            = 28
+      ipv6_support       = false
+      require_acceptance = true
+      accept_attachment  = true
+
+      tags = {
+        env = "prod"
+      }
+    }
+  }
+}
+
+# VPC module (Ireland)
+module "ireland_vpc" {
+  source  = "aws-ia/vpc/aws"
+  version = ">= 3.0.2"
+
+  providers = {
+    aws   = aws.awsireland
+    awscc = awscc.awsccireland
+  }
+
+  name       = "ireland-vpc"
+  cidr_block = "10.0.1.0/24"
+  az_count   = 2
+
+  core_network = {
+    id  = awscc_networkmanager_core_network.core_network.core_network_id
+    arn = awscc_networkmanager_core_network.core_network.core_network_arn
+  }
+  core_network_routes = {
+    workload = "0.0.0.0/0"
+  }
+
+  subnets = {
+    workload = { netmask = 28 }
+    core_network = {
+      netmask            = 28
+      ipv6_support       = false
+      require_acceptance = false
+
+      tags = {
+        env = "nonprod"
+      }
+    }
+  }
+}
+
+# Global Network
+resource "awscc_networkmanager_global_network" "global_network" {
+  provider = awscc.awsccnvirginia
+
+  description = "Global Network - VPC module"
+
+  tags = [{
+    Key   = "Name",
+    Value = "Global Network - VPC module"
+  }]
+}
+
+# Core Network
+resource "awscc_networkmanager_core_network" "core_network" {
+  provider = awscc.awsccnvirginia
+
+  description       = "Core Network - VPC module"
+  global_network_id = awscc_networkmanager_global_network.global_network.id
+  policy_document   = jsonencode(jsondecode(data.aws_networkmanager_core_network_policy_document.policy.json))
+
+  tags = [{
+    key   = "Name",
+    value = "Core Network - VPC module"
+  }]
+}

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,9 +1,9 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  #source  = "aws-ia/vpc/aws"
-  #version = ">= 3.0.2"
-  source = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 3.0.2"
+
   providers = {
     aws   = aws.awsnvirginia
     awscc = awscc.awsccnvirginia

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,9 +1,9 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.2"
-
+  # source  = "aws-ia/vpc/aws"
+  # version = ">= 3.0.2"
+  source = "../.."
   providers = {
     aws   = aws.awsnvirginia
     awscc = awscc.awsccnvirginia
@@ -77,11 +77,6 @@ resource "awscc_networkmanager_global_network" "global_network" {
   provider = awscc.awsccnvirginia
 
   description = "Global Network - VPC module"
-
-  tags = [{
-    Key   = "Name",
-    Value = "Global Network - VPC module"
-  }]
 }
 
 # Core Network

--- a/examples/cloud_wan/outputs.tf
+++ b/examples/cloud_wan/outputs.tf
@@ -1,0 +1,26 @@
+
+output "vpcs" {
+  description = "VPCs created."
+  value = {
+    nvirginia = module.nvirginia_vpc.vpc_attributes.id
+    ireland   = module.ireland_vpc.vpc_attributes.id
+  }
+}
+
+output "global_network" {
+  description = "Global Network ID."
+  value       = awscc_networkmanager_global_network.global_network.id
+}
+
+output "core_network" {
+  description = "Core Network ID."
+  value       = awscc_networkmanager_core_network.core_network.core_network_id
+}
+
+output "core_network_vpc_attachments" {
+  description = "Core Network VPC attachments."
+  value = {
+    nvirginia = module.nvirginia_vpc.core_network_attachment.id
+    ireland   = module.ireland_vpc.core_network_attachment.id
+  }
+}

--- a/examples/cloud_wan/providers.tf
+++ b/examples/cloud_wan/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = "= 0.33.0"
+      version = ">= 0.36.0"
     }
   }
 }

--- a/examples/cloud_wan/providers.tf
+++ b/examples/cloud_wan/providers.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = ">= 0.25.0"
+      version = "= 0.33.0"
     }
   }
 }

--- a/examples/cloud_wan/providers.tf
+++ b/examples/cloud_wan/providers.tf
@@ -1,0 +1,36 @@
+
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.27.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.25.0"
+    }
+  }
+}
+
+# Provider definitios for N. Virginia Region
+provider "aws" {
+  region = var.cloud_wan_regions.nvirginia
+  alias  = "awsnvirginia"
+}
+
+provider "awscc" {
+  region = var.cloud_wan_regions.nvirginia
+  alias  = "awsccnvirginia"
+}
+
+# Provider definitios for Ireland Region
+provider "aws" {
+  region = var.cloud_wan_regions.ireland
+  alias  = "awsireland"
+}
+
+provider "awscc" {
+  region = var.cloud_wan_regions.ireland
+  alias  = "awsccireland"
+}

--- a/examples/cloud_wan/variables.tf
+++ b/examples/cloud_wan/variables.tf
@@ -1,0 +1,13 @@
+
+variable "cloud_wan_regions" {
+  description = "AWS Regions to create in Cloud WAN's core network."
+  type = object({
+    nvirginia = string
+    ireland   = string
+  })
+
+  default = {
+    nvirginia = "us-east-1"
+    ireland   = "eu-west-1"
+  }
+}

--- a/examples/ipam/.terraform-docs.yaml
+++ b/examples/ipam/.terraform-docs.yaml
@@ -1,0 +1,21 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+  lockfile: false
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/ipam/README.md
+++ b/examples/ipam/README.md
@@ -16,7 +16,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ipam_base_for_example_only"></a> [ipam\_base\_for\_example\_only](#module\_ipam\_base\_for\_example\_only) | ../../test/hcl_fixtures/ipam_base | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 3.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 3.0.2 |
 
 ## Resources
 

--- a/examples/ipam/main.tf
+++ b/examples/ipam/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.1"
+  version = ">= 3.0.2"
 
   name     = "ipam-vpc"
   az_count = 3

--- a/examples/public_private_flow_logs/.terraform-docs.yaml
+++ b/examples/public_private_flow_logs/.terraform-docs.yaml
@@ -1,0 +1,21 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+  lockfile: false
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/public_private_flow_logs/README.md
+++ b/examples/public_private_flow_logs/README.md
@@ -9,7 +9,7 @@ At this point, only cloud-watch logs are support, pending: https://github.com/aw
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
 
 ## Providers
@@ -22,7 +22,7 @@ At this point, only cloud-watch logs are support, pending: https://github.com/aw
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../.. | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | aws-ia/vpc/aws | >= 3.0.2 |
 
 ## Resources
 

--- a/examples/public_private_flow_logs/main.tf
+++ b/examples/public_private_flow_logs/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "current" {}
 
 module "vpc" {
   source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.1"
+  version = ">= 3.0.2"
 
   name       = "flowlogs"
   cidr_block = "10.0.0.0/20"

--- a/examples/secondary_cidr/.terraform-docs.yaml
+++ b/examples/secondary_cidr/.terraform-docs.yaml
@@ -1,0 +1,21 @@
+formatter: markdown
+header-from: .header.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  escape: true
+  html: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+  lockfile: false
+
+sort:
+  enabled: true
+  by: required
+
+output:
+  file: README.md
+  mode: replace

--- a/examples/secondary_cidr/README.md
+++ b/examples/secondary_cidr/README.md
@@ -23,7 +23,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_secondary"></a> [secondary](#module\_secondary) | aws-ia/vpc/aws | >= 2.0.0 |
+| <a name="module_secondary"></a> [secondary](#module\_secondary) | aws-ia/vpc/aws | >= 3.0.2 |
 
 ## Resources
 

--- a/examples/secondary_cidr/main.tf
+++ b/examples/secondary_cidr/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 module "secondary" {
   source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.1"
+  version = ">= 3.0.2"
 
   name       = "secondary-cidr"
   az_count   = 2

--- a/examples/transit_gateway/main.tf
+++ b/examples/transit_gateway/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "current" {}
 
 module "vpc" {
   source  = "aws-ia/vpc/aws"
-  version = ">= 3.0.1"
+  version = ">= 3.0.2"
 
   name               = "tgw"
   cidr_block         = "10.0.0.0/16"

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "calculate_subnets" {
   subnets = var.subnets
 }
 
+# VPC RESOURCE (and secondary CIDR blocks - if configured)
 resource "aws_vpc" "main" {
   count = local.create_vpc ? 1 : 0
 
@@ -23,6 +24,7 @@ resource "aws_vpc" "main" {
   )
 }
 
+# Secondary CIDR blocks - if configured
 resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
   count = (var.vpc_secondary_cidr && !local.create_vpc) ? 1 : 0
 
@@ -31,8 +33,9 @@ resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
   ipv4_ipam_pool_id = var.vpc_ipv4_ipam_pool_id
 }
 
-# Public Subnets
+# PUBLIC SUBNET CONFIGURATION
 
+# Public Subnets
 resource "aws_subnet" "public" {
   for_each = contains(local.subnet_keys, "public") ? toset(local.azs) : toset([])
 
@@ -47,6 +50,7 @@ resource "aws_subnet" "public" {
   )
 }
 
+# Public subnet Route Table and association
 resource "awscc_ec2_route_table" "public" {
   for_each = contains(local.subnet_keys, "public") ? toset(local.azs) : toset([])
 
@@ -59,6 +63,14 @@ resource "awscc_ec2_route_table" "public" {
   )
 }
 
+resource "awscc_ec2_subnet_route_table_association" "public" {
+  for_each = contains(local.subnet_keys, "public") ? toset(local.azs) : toset([])
+
+  subnet_id      = aws_subnet.public[each.key].id
+  route_table_id = awscc_ec2_route_table.public[each.key].id
+}
+
+# Elastic IP - used in NAT gateways (if configured)
 resource "aws_eip" "nat" {
   for_each = toset(local.nat_configuration)
   vpc      = true
@@ -70,6 +82,7 @@ resource "aws_eip" "nat" {
   )
 }
 
+# NAT gateways (if configured)
 resource "aws_nat_gateway" "main" {
   for_each = toset(local.nat_configuration)
 
@@ -87,6 +100,7 @@ resource "aws_nat_gateway" "main" {
   ]
 }
 
+# Internet gateway (if public subnets are created)
 resource "aws_internet_gateway" "main" {
   count  = contains(local.subnet_keys, "public") ? 1 : 0
   vpc_id = local.vpc.id
@@ -98,6 +112,7 @@ resource "aws_internet_gateway" "main" {
   )
 }
 
+# Route: from public subnets to the Internet gateway
 resource "aws_route" "public_to_igw" {
   for_each = contains(local.subnet_keys, "public") ? toset(local.azs) : toset([])
 
@@ -106,13 +121,7 @@ resource "aws_route" "public_to_igw" {
   gateway_id             = aws_internet_gateway.main[0].id
 }
 
-resource "awscc_ec2_subnet_route_table_association" "public" {
-  for_each = contains(local.subnet_keys, "public") ? toset(local.azs) : toset([])
-
-  subnet_id      = aws_subnet.public[each.key].id
-  route_table_id = awscc_ec2_route_table.public[each.key].id
-}
-
+# Route: from public subnets to the Transit Gateway (if configured in var.transit_gateway_routes)
 resource "aws_route" "public_to_tgw" {
   for_each = (contains(local.subnet_keys, "public") && contains(local.subnets_tgw_routed, "public")) ? toset(local.azs) : toset([])
 
@@ -123,8 +132,25 @@ resource "aws_route" "public_to_tgw" {
   route_table_id     = awscc_ec2_route_table.public[each.key].id
 }
 
-# Private Subnets
+# Route: from public subnets to AWS Cloud WAN's core network (if configured in var.core_network_routes)
+resource "aws_route" "public_to_cwan" {
+  for_each = (contains(local.subnet_keys, "public") && contains(local.subnets_cwan_routed, "public") && local.create_cwan_routes) ? toset(local.azs) : toset([])
 
+  destination_cidr_block     = can(regex("^pl-", var.core_network_routes["public"])) ? null : var.core_network_routes["public"]
+  destination_prefix_list_id = can(regex("^pl-", var.core_network_routes["public"])) ? var.core_network_routes["public"] : null
+
+  core_network_arn = var.core_network.arn
+  route_table_id   = awscc_ec2_route_table.public[each.key].id
+
+  depends_on = [
+    aws_networkmanager_vpc_attachment.cwan,
+    aws_networkmanager_attachment_accepter.cwan
+  ]
+}
+
+# PRIVATE SUBNETS CONFIGURATION
+
+# Private Subnets
 resource "aws_subnet" "private" {
   for_each = toset(try(local.private_per_az, []))
 
@@ -144,6 +170,7 @@ resource "aws_subnet" "private" {
   ]
 }
 
+# Private subnet Route Table and association
 resource "awscc_ec2_route_table" "private" {
   for_each = toset(try(local.private_per_az, []))
 
@@ -163,6 +190,7 @@ resource "awscc_ec2_subnet_route_table_association" "private" {
   route_table_id = awscc_ec2_route_table.private[each.key].id
 }
 
+# Route: from the private subnet to the NAT gateway (if Internet access configured)
 resource "aws_route" "private_to_nat" {
   for_each = toset(try(local.private_subnet_names_nat_routed, []))
 
@@ -172,6 +200,7 @@ resource "aws_route" "private_to_nat" {
   nat_gateway_id = local.nat_per_az[split("/", each.key)[1]].id
 }
 
+# Route: from private subnets to the Transit Gateway (if configured in var.transit_gateway_routes)
 resource "aws_route" "private_to_tgw" {
   for_each = toset(local.private_subnet_key_names_tgw_routed)
 
@@ -182,8 +211,28 @@ resource "aws_route" "private_to_tgw" {
   transit_gateway_id = var.transit_gateway_id
 }
 
-# Transit Gateway Subnets
+# Route: from private subnets to AWS Cloud WAN's core network (if configured in var.core_network_routes)
+resource "aws_route" "private_to_cwan" {
+  for_each = {
+    for k, v in toset(local.private_subnet_key_names_cwan_routes) : k => v
+    if local.create_cwan_routes
+  }
 
+  destination_cidr_block     = can(regex("^pl-", var.core_network_routes[split("/", each.key)[0]])) ? null : var.core_network_routes[split("/", each.key)[0]]
+  destination_prefix_list_id = can(regex("^pl-", var.core_network_routes[split("/", each.key)[0]])) ? var.core_network_routes[split("/", each.key)[0]] : null
+
+  core_network_arn = var.core_network.arn
+  route_table_id   = awscc_ec2_route_table.private[each.key].id
+
+  depends_on = [
+    aws_networkmanager_vpc_attachment.cwan,
+    aws_networkmanager_attachment_accepter.cwan
+  ]
+}
+
+# TRANSIT GATEWAY SUBNET CONFIGURATION
+
+# Transit Gateway Subnets
 resource "aws_subnet" "tgw" {
   for_each = contains(local.subnet_keys, "transit_gateway") ? toset(local.azs) : toset([])
 
@@ -199,6 +248,7 @@ resource "aws_subnet" "tgw" {
 
 }
 
+# Transit Gateway subnet Route Table and association
 resource "awscc_ec2_route_table" "tgw" {
   for_each = contains(local.subnet_keys, "transit_gateway") ? toset(local.azs) : toset([])
 
@@ -218,6 +268,7 @@ resource "awscc_ec2_subnet_route_table_association" "tgw" {
   route_table_id = awscc_ec2_route_table.tgw[each.key].id
 }
 
+# Route: from transit_gateway subnet to NAT gateway (if Internet access configured)
 resource "aws_route" "tgw_to_nat" {
   for_each = (try(var.subnets.transit_gateway.connect_to_public_natgw == true, false) && contains(local.subnet_keys, "public")) ? toset(local.azs) : toset([])
 
@@ -228,6 +279,7 @@ resource "aws_route" "tgw_to_nat" {
   nat_gateway_id = local.nat_per_az[each.key].id
 }
 
+# Transit Gateway VPC attachment
 resource "aws_ec2_transit_gateway_vpc_attachment" "tgw" {
   count = contains(local.subnet_keys, "transit_gateway") ? 1 : 0
 
@@ -248,8 +300,83 @@ resource "aws_ec2_transit_gateway_route_table_association" "tgw" {
   transit_gateway_route_table_id = var.subnets.transit_gateway.transit_gateway_route_table_id
 }
 
-# Flow Logs
+# CORE NETWORK SUBNET CONFIGURATION
 
+# Core Network Subnets
+resource "aws_subnet" "cwan" {
+  for_each = contains(local.subnet_keys, "core_network") ? toset(local.azs) : toset([])
+
+  availability_zone = each.key
+  vpc_id            = local.vpc.id
+  cidr_block        = local.calculated_subnets["core_network"][each.key]
+
+  tags = merge(
+    { Name = "${local.subnet_names["core_network"]}-${each.key}" },
+    module.tags.tags_aws,
+    try(module.subnet_tags["core_network"].tags_aws, {})
+  )
+}
+
+# Core Network subnet Route Table and association
+resource "awscc_ec2_route_table" "cwan" {
+  for_each = contains(local.subnet_keys, "core_network") ? toset(local.azs) : toset([])
+
+  vpc_id = local.vpc.id
+
+  tags = concat(
+    [{ "key" = "Name", "value" = "${local.subnet_names["core_network"]}-${each.key}" }],
+    module.tags.tags,
+    try(module.subnet_tags["core_network"].tags, [])
+  )
+}
+
+resource "awscc_ec2_subnet_route_table_association" "cwan" {
+  for_each = contains(local.subnet_keys, "core_network") ? toset(local.azs) : toset([])
+
+  subnet_id      = aws_subnet.cwan[each.key].id
+  route_table_id = awscc_ec2_route_table.cwan[each.key].id
+}
+
+# Route: from core_network subnet to NAT gateway (if Internet access configured)
+resource "aws_route" "cwan_to_nat" {
+  for_each = (try(var.subnets.core_network.connect_to_public_natgw == true, false) && contains(local.subnet_keys, "public")) ? toset(local.azs) : toset([])
+
+  route_table_id         = awscc_ec2_route_table.cwan[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  # try to get nat for AZ, else use singular nat
+  nat_gateway_id = local.nat_per_az[each.key].id
+}
+
+# AWS Cloud WAN's Core Network VPC attachment
+resource "aws_networkmanager_vpc_attachment" "cwan" {
+  count = contains(local.subnet_keys, "core_network") ? 1 : 0
+
+  core_network_id = var.core_network.id
+  subnet_arns     = values(aws_subnet.cwan)[*].arn
+  vpc_arn         = local.vpc.arn
+
+  options {
+    ipv6_support = try(var.subnets.core_nework.ipv6_support, false)
+  }
+
+  tags = merge(
+    { Name = "${var.name}-vpc_attachment" },
+    module.subnet_tags["core_network"].tags_aws
+  )
+}
+
+# Core Network's attachment acceptance (if required)
+resource "aws_networkmanager_attachment_accepter" "cwan" {
+  count = contains(local.subnet_keys, "core_network") && local.create_acceptance ? 1 : 0
+
+  attachment_id   = aws_networkmanager_vpc_attachment.cwan[0].id
+  attachment_type = "VPC"
+}
+
+# Core Network VPC attachment acceptance (if required)
+# TO ADD
+
+# FLOW LOGS
 module "flow_logs" {
   count = local.create_flow_logs ? 1 : 0
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "transit_gateway_attachment_id" {
   value       = try(aws_ec2_transit_gateway_vpc_attachment.tgw[0].id, null)
 }
 
+output "core_network_attachment" {
+  description = "AWS Cloud WAN's core network attachment. Full output of aws_networkmanager_vpc_attachment."
+  value       = try(aws_networkmanager_vpc_attachment.cwan[0], null)
+}
+
 output "private_subnet_attributes_by_az" {
   value       = try(aws_subnet.private, null)
   description = <<-EOF
@@ -73,12 +78,33 @@ output "tgw_subnet_attributes_by_az" {
 EOF
 }
 
+output "core_network_subnet_attributes_by_az" {
+  value       = try(aws_subnet.cwan, null)
+  description = <<-EOF
+  Map of all core_network subnets containing their attributes.
+
+  Example:
+  ```
+  core_network_subnet_attributes = {
+    "us-east-1a" = {
+      "arn" = "arn:aws:ec2:us-east-1:<>:subnet/subnet-04a86315c4839b519"
+      "assign_ipv6_address_on_creation" = false
+      ...
+      <all attributes of subnet: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference>
+    }
+    "us-east-1b" = {...)
+  }
+  ```
+EOF
+}
+
 output "rt_attributes_by_type_by_az" {
   value = {
     # TODO: omit keys if value is null
     "private"         = awscc_ec2_route_table.private,
     "public"          = awscc_ec2_route_table.public
     "transit_gateway" = awscc_ec2_route_table.tgw
+    "core_network"    = awscc_ec2_route_table.cwan
   }
   description = <<-EOF
   Map of route tables by type => az => route table attributes. Example usage: module.vpc.route_table_by_subnet_type.private.id

--- a/providers.tf
+++ b/providers.tf
@@ -7,7 +7,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = ">= 0.15.0"
+      version = "= 0.33.0"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,7 +7,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = "= 0.33.0"
+      version = ">= 0.36.0"
     }
   }
 }

--- a/test/examples_cloud_wan_test.go
+++ b/test/examples_cloud_wan_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestExamplesTransitGateway(t *testing.T) {
+	
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/cloud_wan",
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}

--- a/test/examples_cloud_wan_test.go
+++ b/test/examples_cloud_wan_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestExamplesTransitGateway(t *testing.T) {
+func TestExamplesCloudWAN(t *testing.T) {
 	
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../examples/cloud_wan",


### PR DESCRIPTION
Adding Cloud WAN support:

* Creation of core_network subnets.
* Creation of Core Network's VPC attachment.
* Support for attachment acceptance for VPC attachments.