### PR TITLE
fix: fixed bug on ipv6_subnets_cwan_routed local variable 

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -45,7 +45,7 @@ locals {
   private_subnet_key_names_cwan_routes = [for subnet in local.private_per_az : subnet if contains(local.subnets_cwan_routed, split("/", subnet)[0])]
 
   # support variables for core_network_ipv6_routes
-  ipv6_subnets_cwan_routed                   = keys(var.core_network_routes)
+  ipv6_subnets_cwan_routed                   = keys(var.core_network_ipv6_routes)
   ipv6_private_subnet_keys_names_cwan_routes = [for subnet in local.private_per_az : subnet if contains(local.ipv6_subnets_cwan_routed, split("/", subnet)[0])]
 
   # support variables for core_network subnets

--- a/examples/cloud_wan/README.md
+++ b/examples/cloud_wan/README.md
@@ -28,8 +28,8 @@ This example shows how you can use this module with `core_network` subnets, and 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | aws-ia/vpc/aws | >= 4.2.0 |
-| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | aws-ia/vpc/aws | >= 4.2.0 |
+| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | ../.. | n/a |
+| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | ../.. | n/a |
 
 ## Resources
 

--- a/examples/cloud_wan/README.md
+++ b/examples/cloud_wan/README.md
@@ -28,8 +28,8 @@ This example shows how you can use this module with `core_network` subnets, and 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | ../.. | n/a |
-| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | ../.. | n/a |
+| <a name="module_ireland_vpc"></a> [ireland\_vpc](#module\_ireland\_vpc) | aws-ia/vpc/aws | >= 4.2.0 |
+| <a name="module_nvirginia_vpc"></a> [nvirginia\_vpc](#module\_nvirginia\_vpc) | aws-ia/vpc/aws | >= 4.2.0 |
 
 ## Resources
 

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -50,7 +50,7 @@ module "ireland_vpc" {
 
   name                                 = "ireland-vpc"
   cidr_block                           = "10.0.1.0/24"
-  vpc_assign_generated_ipv6_cidr_block = false
+  vpc_assign_generated_ipv6_cidr_block = true
   az_count                             = 2
 
   core_network = {
@@ -60,14 +60,17 @@ module "ireland_vpc" {
   core_network_routes = {
     workload = "0.0.0.0/0"
   }
+  core_network_ipv6_routes = {
+    workload = "::/0"
+  }
   subnets = {
     workload = {
       netmask          = 28
-      assign_ipv6_cidr = false
+      assign_ipv6_cidr = true
     }
     core_network = {
       netmask            = 28
-      assign_ipv6_cidr   = false
+      assign_ipv6_cidr   = true
       require_acceptance = false
 
       tags = {

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,8 +1,7 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  source    = "aws-ia/vpc/aws"
-  version   = ">= 4.2.0"
+  source    = "../.."
   providers = { aws = aws.awsnvirginia }
 
   name                                 = "nvirginia-vpc"
@@ -42,13 +41,12 @@ module "nvirginia_vpc" {
 
 # VPC module (Ireland)
 module "ireland_vpc" {
-  source    = "aws-ia/vpc/aws"
-  version   = ">= 4.2.0"
+  source    = "../.."
   providers = { aws = aws.awsireland }
 
   name                                 = "ireland-vpc"
   cidr_block                           = "10.0.1.0/24"
-  vpc_assign_generated_ipv6_cidr_block = true
+  vpc_assign_generated_ipv6_cidr_block = false
   az_count                             = 2
 
   core_network = {
@@ -58,18 +56,14 @@ module "ireland_vpc" {
   core_network_routes = {
     workload = "0.0.0.0/0"
   }
-  core_network_ipv6_routes = {
-    workload = "::/0"
-  }
-
   subnets = {
     workload = {
       netmask          = 28
-      assign_ipv6_cidr = true
+      assign_ipv6_cidr = false
     }
     core_network = {
       netmask            = 28
-      assign_ipv6_cidr   = true
+      assign_ipv6_cidr   = false
       require_acceptance = false
 
       tags = {

--- a/examples/cloud_wan/main.tf
+++ b/examples/cloud_wan/main.tf
@@ -1,7 +1,9 @@
 
 # VPC module (North Virginia)
 module "nvirginia_vpc" {
-  source    = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 4.2.0"
+
   providers = { aws = aws.awsnvirginia }
 
   name                                 = "nvirginia-vpc"
@@ -41,7 +43,9 @@ module "nvirginia_vpc" {
 
 # VPC module (Ireland)
 module "ireland_vpc" {
-  source    = "../.."
+  source  = "aws-ia/vpc/aws"
+  version = ">= 4.2.0"
+
   providers = { aws = aws.awsireland }
 
   name                                 = "ireland-vpc"


### PR DESCRIPTION
I noticed there was a minor bug on core_network_routes , when one passes a map of the routes to go to the cwan , the ipv6 routes local variable references the the ipv4 routes which throws an unexpected error whilst trying to deploy ipv4 routes only it also tries to deploy ipv6 routes.

Moreover, I updated the example to have a hybrid sort of example to test the expected behavior .

Love the module btw!