### PR TITLE
add support for customizing log format

### DIFF
--- a/modules/flow_logs/main.tf
+++ b/modules/flow_logs/main.tf
@@ -40,7 +40,7 @@ resource "aws_flow_log" "main" {
   log_destination_type = var.flow_log_definition.log_destination_type
   traffic_type         = var.flow_log_definition.traffic_type
   vpc_id               = var.vpc_id
-
+  log_format           = var.flow_log_definition.log_format
   dynamic "destination_options" {
     for_each = var.flow_log_definition.log_destination_type == "s3" ? [true] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -265,11 +265,11 @@ variable "vpc_flow_logs" {
   description = "Whether or not to create VPC flow logs and which type. Options: \"cloudwatch\", \"s3\", \"none\". By default creates flow logs to `cloudwatch`. Variable overrides null value types for some keys, defined in defaults.tf."
 
   type = object({
-    name_override   = optional(string, "")
-    log_destination = optional(string)
-    iam_role_arn    = optional(string)
-    kms_key_id      = optional(string)
-
+    name_override        = optional(string, "")
+    log_destination      = optional(string)
+    iam_role_arn         = optional(string)
+    kms_key_id           = optional(string)
+    log_format           = optional(string)
     log_destination_type = string
     retention_in_days    = optional(number)
     tags                 = optional(map(string))


### PR DESCRIPTION
This pull request implements a requirement that we have with regards to changing the log format of the vpc flow log
Currently flow log default format only lists the ENI and not the VPCID
As we have several ENIs in each VPC it would be easier to summarize data using the VPCID field and therefore we need to use a custom format