### PR TITLE
Fix: flow log warning issue

### DIFF
--- a/modules/flow_logs/modules/s3_log_bucket/main.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/main.tf
@@ -35,6 +35,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
       storage_class = "STANDARD_IA"
     }
 
+    filter {
+      prefix = ""
+    }
+
     expiration {
       days = 60
     }


### PR DESCRIPTION
Description:
This PR addresses the warning related to an invalid attribute combination in the aws_s3_bucket_lifecycle_configuration resource within the flow_logs module. The warning states that no attribute has been specified, while one (and only one) of [rule[0].prefix.<.filter] is required.

Changes Made:
	•	Updated the aws_s3_bucket_lifecycle_configuration resource in flow log's main.tf to explicitly define the required attribute (prefix or filter).