### PR TITLE
Fixed flow log bucket filter bug

### DIFF
--- a/modules/flow_logs/main.tf
+++ b/modules/flow_logs/main.tf
@@ -31,7 +31,8 @@ module "s3_log_bucket" {
   count  = (local.create_flow_log_destination && var.flow_log_definition.log_destination_type == "s3") ? 1 : 0
   source = "./modules/s3_log_bucket"
 
-  name = var.name
+  name                    = var.name
+  lifecycle_filter_prefix = var.log_bucket_lifecycle_filter_prefix
 }
 
 resource "aws_flow_log" "main" {

--- a/modules/flow_logs/modules/s3_log_bucket/main.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/main.tf
@@ -30,6 +30,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
   rule {
     id = "transition"
 
+    filter {
+      prefix = var.lifecycle_filter_prefix
+    }
+
     transition {
       days          = 30
       storage_class = "STANDARD_IA"

--- a/modules/flow_logs/modules/s3_log_bucket/variables.tf
+++ b/modules/flow_logs/modules/s3_log_bucket/variables.tf
@@ -2,3 +2,9 @@ variable "name" {
   type        = string
   description = "(optional) describe your variable"
 }
+
+variable "lifecycle_filter_prefix" {
+  description = "Prefix to use for the lifecycle transition rule"
+  type        = string
+  default     = ""
+}

--- a/modules/flow_logs/variables.tf
+++ b/modules/flow_logs/variables.tf
@@ -18,3 +18,8 @@ variable "tags" {
   type        = map(string)
   default     = null
 }
+
+variable "log_bucket_lifecycle_filter_prefix" {
+  description = "Prefix to use for the lifecycle transition rule in the flowlogs bucket"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -270,15 +270,21 @@ variable "vpc_flow_logs" {
     iam_role_arn    = optional(string)
     kms_key_id      = optional(string)
 
-    log_destination_type = string
-    retention_in_days    = optional(number)
-    tags                 = optional(map(string))
-    traffic_type         = optional(string, "ALL")
+    log_destination_type               = string
+    retention_in_days                  = optional(number)
+    log_bucket_lifecycle_filter_prefix = optional(string, null)
+    tags                               = optional(map(string))
+    traffic_type                       = optional(string, "ALL")
     destination_options = optional(object({
       file_format                = optional(string, "plain-text")
       hive_compatible_partitions = optional(bool, false)
       per_hour_partition         = optional(bool, false)
-    }))
+      }),
+      {
+        file_format                = "plain-text"
+        hive_compatible_partitions = false
+        per_hour_partition         = false
+    })
   })
 
   default = {


### PR DESCRIPTION
Fixed the ominious ominous warning:

```
Warning: Invalid Attribute Combination
...
No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required
...
This will be an error in a future version of the provider
```

is fixed in this commit by adding an empty string prefix by default. It's configurable in case people want to have a real prefix