### PR TITLE
Set assign_ipv6_address_on_creation if private dualstack

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -100,8 +100,6 @@ locals {
   # Checking if public subnets are dual-stack or IPv6-only
   public_ipv6only  = can(var.subnets.public.ipv6_native)
   public_dualstack = !local.public_ipv6only && (can(var.subnets.public.assign_ipv6_cidr) || can(var.subnets.public.ipv6_cidrs))
-  private_ipv6only  = can(var.subnets.private.ipv6_native)
-  private_dualstack = !local.private_ipv6only && (can(var.subnets.private.assign_ipv6_cidr) || can(var.subnets.private.ipv6_cidrs))
   # Checking if transit_gateway subnets are dual-stack
   tgw_dualstack = (can(var.subnets.transit_gateway.assign_ipv6_cidr) || can(var.subnets.transit_gateway.ipv6_cidrs))
   # Checking if core_network subnets are dual-stack

--- a/data.tf
+++ b/data.tf
@@ -100,6 +100,8 @@ locals {
   # Checking if public subnets are dual-stack or IPv6-only
   public_ipv6only  = can(var.subnets.public.ipv6_native)
   public_dualstack = !local.public_ipv6only && (can(var.subnets.public.assign_ipv6_cidr) || can(var.subnets.public.ipv6_cidrs))
+  private_ipv6only  = can(var.subnets.private.ipv6_native)
+  private_dualstack = !local.private_ipv6only && (can(var.subnets.private.assign_ipv6_cidr) || can(var.subnets.private.ipv6_cidrs))
   # Checking if transit_gateway subnets are dual-stack
   tgw_dualstack = (can(var.subnets.transit_gateway.assign_ipv6_cidr) || can(var.subnets.transit_gateway.ipv6_cidrs))
   # Checking if core_network subnets are dual-stack

--- a/main.tf
+++ b/main.tf
@@ -235,10 +235,10 @@ resource "aws_subnet" "private" {
   vpc_id                                         = local.vpc.id
   cidr_block                                     = can(local.calculated_subnets[split("/", each.key)[0]][split("/", each.key)[1]]) ? local.calculated_subnets[split("/", each.key)[0]][split("/", each.key)[1]] : null
   ipv6_cidr_block                                = can(local.calculated_subnets_ipv6[split("/", each.key)[0]][split("/", each.key)[1]]) ? local.calculated_subnets_ipv6[split("/", each.key)[0]][split("/", each.key)[1]] : null
-  ipv6_native                                    = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : false
+  ipv6_native                                    = local.private_ipv6only
   map_public_ip_on_launch                        = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? null : false
-  assign_ipv6_address_on_creation                = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : try(var.subnets[each.key].assign_ipv6_address_on_creation, false)
-  enable_resource_name_dns_aaaa_record_on_launch = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : try(var.subnets[each.key].enable_resource_name_dns_aaaa_record_on_launch, false)
+  assign_ipv6_address_on_creation                = local.private_ipv6only || local.private_dualstack ? true : null
+  enable_resource_name_dns_aaaa_record_on_launch = local.private_ipv6only || local.private_dualstack ? true : false
 
   tags = merge(
     { Name = "${local.subnet_names[split("/", each.key)[0]]}-${split("/", each.key)[1]}" },

--- a/main.tf
+++ b/main.tf
@@ -235,10 +235,10 @@ resource "aws_subnet" "private" {
   vpc_id                                         = local.vpc.id
   cidr_block                                     = can(local.calculated_subnets[split("/", each.key)[0]][split("/", each.key)[1]]) ? local.calculated_subnets[split("/", each.key)[0]][split("/", each.key)[1]] : null
   ipv6_cidr_block                                = can(local.calculated_subnets_ipv6[split("/", each.key)[0]][split("/", each.key)[1]]) ? local.calculated_subnets_ipv6[split("/", each.key)[0]][split("/", each.key)[1]] : null
-  ipv6_native                                    = local.private_ipv6only
+  ipv6_native                                    = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : false
   map_public_ip_on_launch                        = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? null : false
-  assign_ipv6_address_on_creation                = local.private_ipv6only || local.private_dualstack ? true : null
-  enable_resource_name_dns_aaaa_record_on_launch = local.private_ipv6only || local.private_dualstack ? true : false
+  assign_ipv6_address_on_creation                = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : try(var.subnets[split("/", each.key)[0]].assign_ipv6_address_on_creation, false)
+  enable_resource_name_dns_aaaa_record_on_launch = contains(local.subnets_with_ipv6_native, split("/", each.key)[0]) ? true : try(var.subnets[split("/", each.key)[0]].enable_resource_name_dns_aaaa_record_on_launch, false)
 
   tags = merge(
     { Name = "${local.subnet_names[split("/", each.key)[0]]}-${split("/", each.key)[1]}" },


### PR DESCRIPTION
This automatically sets `assign_ipv6_address_on_creation = true` if a private subnet is ipv6 native or dualstack. Currently there is no way to set this flag for dualstack private subnets rendering this module useless for EKS.

Fixes #148 