### PR TITLE
v4.6: BYOIP NAT support, role-based outputs, Cloud WAN & IPAM fixes, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI - Lint & Validate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_wrapper: false
+
+      - name: Init TFLint
+        run: tflint --init --config .tflint.hcl
+
+      - name: Run TFLint
+        run: tflint --config .tflint.hcl --recursive
+
+      - name: Setup terraform-docs
+        uses: jaxxstorm/action-install-gh-release@v2
+        with:
+          repo: terraform-docs/terraform-docs
+          tag: v0.19.0
+
+      - name: Check docs are up to date
+        run: |
+          terraform-docs --config .terraform-docs.yaml .
+          if ! git diff --exit-code README.md; then
+            echo "::error::README.md is out of date. Run 'terraform-docs .' locally and commit."
+            exit 1
+          fi
+
+  validate:
+    name: Validate (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - root
+          - examples/basic
+          - examples/advanced
+          - examples/ipam
+          - examples/transit_gateway
+          - examples/cloud_wan
+          - examples/vpc_lattice
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        working-directory: ${{ matrix.target == 'root' && '.' || matrix.target }}
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: ${{ matrix.target == 'root' && '.' || matrix.target }}
+        run: terraform validate

--- a/.header.md
+++ b/.header.md
@@ -247,6 +247,63 @@ Terraform Plan:
 ...
 ```
 
+# BYOIP (Bring Your Own IP) for NAT Gateway EIPs
+
+You can control how Elastic IPs are sourced for NAT Gateways using the `nat_gateway_eip_configuration` variable. Three modes are available:
+
+## Default (create)
+
+When `nat_gateway_eip_configuration` is not set (or `mode = "create"`), EIPs are allocated from Amazon's default pool. This is the existing behaviour — no changes required for current users.
+
+## BYOIP Pool
+
+Allocate EIPs from a customer-owned public IPv4 address pool:
+
+```hcl
+module "vpc" {
+  source  = "aws-ia/vpc/aws"
+  version = ">= 4.6.0"
+
+  name       = "byoip-vpc"
+  cidr_block = "10.0.0.0/16"
+  az_count   = 3
+
+  subnets = {
+    public = {
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+
+  nat_gateway_eip_configuration = {
+    mode             = "byoip_pool"
+    public_ipv4_pool = "ipv4pool-ec2-xxxxxxxxxxxxxxxxx"
+  }
+}
+```
+
+## Existing EIPs
+
+Use pre-allocated EIP allocation IDs (e.g., managed outside this module):
+
+```hcl
+nat_gateway_eip_configuration = {
+  mode = "existing"
+  allocation_ids = {
+    "us-east-1a" = "eipalloc-0123456789abcdef0"
+    "us-east-1b" = "eipalloc-0123456789abcdef1"
+  }
+}
+```
+
+When `mode = "existing"`, the module does **not** create `aws_eip` resources — it attaches the provided allocation IDs directly to the NAT Gateways. Keys must match the AZ names where NAT Gateways will be deployed.
+
+Credit: Inspired by community PR#179 ([@hminaee-tc](https://github.com/hminaee-tc)).
+
 # Common Errors and their Fixes
 
 ## Error creating routes to Core Network

--- a/.header.md
+++ b/.header.md
@@ -297,6 +297,28 @@ subnets = {
 
 * Alternatively, you can also not configure any subnet route (`var.core_network_routes`) to the Core Network until the attachment gets accepted.
 
+## Production Recommendation: Explicit `cidrs` over `netmask`
+
+For production deployments, prefer explicit `cidrs` over calculated `netmask` to avoid subnet replacement on changes.
+
+When using `netmask`, CIDRs are calculated positionally based on lexicographic ordering of subnet key names. Adding or removing a subnet type (e.g., adding `database = { netmask = 26 }`) can shift CIDRs assigned to existing subnets — causing Terraform to destroy and recreate them, resulting in downtime.
+
+```hcl
+# ⚠️ Development only — CIDRs shift if you add/remove subnet types
+subnets = {
+  private = { netmask = 24 }
+  public  = { netmask = 24 }
+}
+
+# ✅ Production-safe — CIDRs are pinned regardless of key changes
+subnets = {
+  private = { cidrs = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"] }
+  public  = { cidrs = ["10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"] }
+}
+```
+
+This is particularly important when using multiple private subnet roles (e.g., `private`, `isolated`, `database`) since alphabetical ordering determines CIDR allocation.
+
 # Contributing
 
 Please see our [developer documentation](https://github.com/aws-ia/terraform-aws-vpc/blob/main/contributing.md) for guidance on contributing to this module.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,63 @@ Terraform Plan:
 ...
 ```
 
+# BYOIP (Bring Your Own IP) for NAT Gateway EIPs
+
+You can control how Elastic IPs are sourced for NAT Gateways using the `nat_gateway_eip_configuration` variable. Three modes are available:
+
+## Default (create)
+
+When `nat_gateway_eip_configuration` is not set (or `mode = "create"`), EIPs are allocated from Amazon's default pool. This is the existing behaviour — no changes required for current users.
+
+## BYOIP Pool
+
+Allocate EIPs from a customer-owned public IPv4 address pool:
+
+```hcl
+module "vpc" {
+  source  = "aws-ia/vpc/aws"
+  version = ">= 4.6.0"
+
+  name       = "byoip-vpc"
+  cidr_block = "10.0.0.0/16"
+  az_count   = 3
+
+  subnets = {
+    public = {
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+
+  nat_gateway_eip_configuration = {
+    mode             = "byoip_pool"
+    public_ipv4_pool = "ipv4pool-ec2-xxxxxxxxxxxxxxxxx"
+  }
+}
+```
+
+## Existing EIPs
+
+Use pre-allocated EIP allocation IDs (e.g., managed outside this module):
+
+```hcl
+nat_gateway_eip_configuration = {
+  mode = "existing"
+  allocation_ids = {
+    "us-east-1a" = "eipalloc-0123456789abcdef0"
+    "us-east-1b" = "eipalloc-0123456789abcdef1"
+  }
+}
+```
+
+When `mode = "existing"`, the module does **not** create `aws_eip` resources — it attaches the provided allocation IDs directly to the NAT Gateways. Keys must match the AZ names where NAT Gateways will be deployed.
+
+Credit: Inspired by community PR#179 ([@hminaee-tc](https://github.com/hminaee-tc)).
+
 # Common Errors and their Fixes
 
 ## Error creating routes to Core Network
@@ -298,6 +355,28 @@ subnets = {
 
 * Alternatively, you can also not configure any subnet route (`var.core_network_routes`) to the Core Network until the attachment gets accepted.
 
+## Production Recommendation: Explicit `cidrs` over `netmask`
+
+For production deployments, prefer explicit `cidrs` over calculated `netmask` to avoid subnet replacement on changes.
+
+When using `netmask`, CIDRs are calculated positionally based on lexicographic ordering of subnet key names. Adding or removing a subnet type (e.g., adding `database = { netmask = 26 }`) can shift CIDRs assigned to existing subnets — causing Terraform to destroy and recreate them, resulting in downtime.
+
+```hcl
+# ⚠️ Development only — CIDRs shift if you add/remove subnet types
+subnets = {
+  private = { netmask = 24 }
+  public  = { netmask = 24 }
+}
+
+# ✅ Production-safe — CIDRs are pinned regardless of key changes
+subnets = {
+  private = { cidrs = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"] }
+  public  = { cidrs = ["10.0.3.0/24", "10.0.4.0/24", "10.0.5.0/24"] }
+}
+```
+
+This is particularly important when using multiple private subnet roles (e.g., `private`, `isolated`, `database`) since alphabetical ordering determines CIDR allocation.
+
 # Contributing
 
 Please see our [developer documentation](https://github.com/aws-ia/terraform-aws-vpc/blob/main/contributing.md) for guidance on contributing to this module.
@@ -305,20 +384,20 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_calculate_subnets"></a> [calculate\_subnets](#module\_calculate\_subnets) | ./modules/calculate_subnets | n/a |
 | <a name="module_calculate_subnets_ipv6"></a> [calculate\_subnets\_ipv6](#module\_calculate\_subnets\_ipv6) | ./modules/calculate_subnets_ipv6 | n/a |
 | <a name="module_flow_logs"></a> [flow\_logs](#module\_flow\_logs) | ./modules/flow_logs | n/a |
@@ -329,7 +408,7 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_ec2_transit_gateway_vpc_attachment.tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
 | [aws_egress_only_internet_gateway.eigw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/egress_only_internet_gateway) | resource |
 | [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
@@ -372,21 +451,23 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_name"></a> [name](#input\_name) | Name to give VPC. Note: does not effect subnet names, which get assigned name based on name\_prefix. | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Configuration of subnets to build in VPC. 1 Subnet per AZ is created. Subnet types are defined as maps with the available keys: "private", "public", "transit\_gateway", "core\_network". Each Subnet type offers its own set of available arguments detailed below. Subnets are calculated in lexicographical order of the keys in the map.<br/><br/>**Attributes shared across subnet types:**<br/>- `cidrs`            = (Optional\|list(string)) **Cannot set if `netmask` is set.** List of IPv4 CIDRs to set to subnets. Count of CIDRs defined must match quantity of azs in `az_count`.<br/>- `netmask`          = (Optional\|Int) **Cannot set if `cidrs` is set.** Netmask of the `var.cidr_block` to calculate for each subnet.<br/>- `assign_ipv6_cidr` = (Optional\|bool) **Cannot set if `ipv6_cidrs` is set.** If true, it will calculate a /64 block from the IPv6 VPC CIDR to set in the subnets.<br/>- `ipv6_cidrs`       = (Optional\|list(string)) **Cannot set if `assign_ipv6_cidr` is set.** List of IPv6 CIDRs to set to subnets. The subnet size must use a /64 prefix length. Count of CIDRs defined must match quantity of azs in `az_count`.<br/>- `name_prefix`      = (Optional\|String) A string prefix to use for the name of your subnet and associated resources. Subnet type key name is used if omitted (aka private, public, transit\_gateway). Example `name_prefix = "private"` for `var.subnets.private` is redundant.<br/>- `tags`             = (Optional\|map(string)) Tags to set on the subnet and associated resources.<br/><br/>**Any private subnet type options:**<br/>- All shared keys above<br/>- `connect_to_public_natgw` = (Optional\|bool) Determines if routes to NAT Gateways should be created. Must also set `var.subnets.public.nat_gateway_configuration` in public subnets.<br/>- `ipv6_native`             = (Optional\|bool) Indicates whether to create an IPv6-ony subnet. Either `var.assign_ipv6_cidr` or `var.ipv6_cidrs` should be defined to allocate an IPv6 CIDR block.<br/>- `connect_to_eigw`         = (Optional\|bool) Determines if routes to the Egress-only Internet gateway should be created. Must also set `var.vpc_egress_only_internet_gateway`.<br/><br/>**public subnet type options:**<br/>- All shared keys above<br/>- `nat_gateway_configuration` = (Optional\|string) Determines if NAT Gateways should be created and in how many AZs. Valid values = `"none"`, `"single_az"`, `"all_azs"`. Default = "none". Must also set `var.subnets.private.connect_to_public_natgw = true`.<br/>- `connect_to_igw`            = (Optional\|bool) Determines if the default route (0.0.0.0/0 or ::/0) is created in the public subnets with destination the Internet gateway. Defaults to `true`.<br/>- `ipv6_native`               = (Optional\|bool) Indicates whether to create an IPv6-ony subnet. Either `var.assign_ipv6_cidr` or `var.ipv6_cidrs` should be defined to allocate an IPv6 CIDR block.<br/>- `map_public_ip_on_launch`   = (Optional\|bool) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default to `false`.<br/><br/>**transit\_gateway subnet type options:**<br/>- All shared keys above<br/>- `connect_to_public_natgw`                            = (Optional\|string) Determines if routes to NAT Gateways should be created. Specify the CIDR range or a prefix-list-id that you want routed to nat gateway. Usually `0.0.0.0/0`. Must also set `var.subnets.public.nat_gateway_configuration`.<br/>- `transit_gateway_default_route_table_association`    = (Optional\|bool) Boolean whether the VPC Attachment should be associated with the EC2 Transit Gateway association default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways.<br/>- `transit_gateway_default_route_table_propagation`    = (Optional\|bool) Boolean whether the VPC Attachment should propagate routes with the EC2 Transit Gateway propagation default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways.<br/>- `transit_gateway_appliance_mode_support`             = (Optional\|string) Whether Appliance Mode is enabled. If enabled, a traffic flow between a source and a destination uses the same Availability Zone for the VPC attachment for the lifetime of that flow. Valid values: `disable` (default) and `enable`.<br/>- `transit_gateway_dns_support`                        = (Optional\|string) DNS Support is used if you need the VPC to resolve public IPv4 DNS host names to private IPv4 addresses when queried from instances in another VPC attached to the transit gateway. Valid values: `enable` (default) and `disable`.<br/>- `transit_gateway_security_group_referencing_support` = (Optional\|string) Security group referencing support enables you to simplify Security group management and control of instance-to-instance traffic across VPCs that are connected by Transit gateway. Valid values: `disable` and `enable` (default).<br/><br/>**core\_network subnet type options:**<br/>- All shared keys abovce<br/>- `connect_to_public_natgw` = (Optional\|string) Determines if routes to NAT Gateways should be created. Specify the CIDR range or a prefix-list-id that you want routed to nat gateway. Usually `0.0.0.0/0`. Must also set `var.subnets.public.nat_gateway_configuration`.<br/>- `appliance_mode_support`  = (Optional\|bool) Indicates whether appliance mode is supported. If enabled, traffic flow between a source and destination use the same Availability Zone for the VPC attachment for the lifetime of that flow. Defaults to `false`.<br/>- `require_acceptance`      = (Optional\|bool) Boolean whether the core network VPC attachment to create requires acceptance or not. Defaults to `false`.<br/>- `accept_attachment`       = (Optional\|bool) Boolean whether the core network VPC attachment is accepted or not in the segment. Only valid if `require_acceptance` is set to `true`. Defaults to `true`.<br/><br/>Example:<pre>subnets = {<br/>  # Dual-stack subnet<br/>  public = {<br/>    netmask                   = 24<br/>    assign_ipv6_cidr          = true<br/>    nat_gateway_configuration = "single_az"<br/>  }<br/>  # IPv4 only subnet<br/>  private = {<br/>    netmask                  = 24<br/>    connect_to_public_natgw  = true<br/>  }<br/>  # IPv6 only subnet<br/>  ipv6 = {<br/>    ipv6_native      = true<br/>    assign_ipv6_cidr = true<br/>    connect_to_eigw  = true<br/>  }<br/>  # Transit gateway subnets (dual-stack)<br/>  transit_gateway = {<br/>    netmask                                         = 24<br/>    assign_ipv6_cidr                                = true<br/>    connect_to_public_natgw                         = true<br/>    transit_gateway_default_route_table_association = true<br/>    transit_gateway_default_route_table_propagation = true<br/>  }<br/>  # Core Network subnets (dual-stack)<br/>  core_network = {<br/>    netmask                 = 24<br/>    assign_ipv6_cidr        = true<br/>    connect_to_public_natgw = true<br/>    appliance_mode_support  = true<br/>    require_acceptance      = true<br/>    accept_attachment       = true<br/>  }<br/>}</pre> | `any` | n/a | yes |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Searches region for # of AZs to use and takes a slice based on count. Assume slice is sorted a-z. Required if `azs` is not provided. | `number` | `null` | no |
-| <a name="input_azs"></a> [azs](#input\_azs) | (Optional) A list of AZs to use. e.g. `azs = ["us-east-1a","us-east-1c"]` Incompatible with `az_count` | `list(string)` | `[]` | no |
+| <a name="input_azs"></a> [azs](#input\_azs) | (Optional) A list of AZs to use. e.g. `azs = ["us-east-1a","us-east-1c"]` Incompatible with `az_count` | `list(string)` | `null` | no |
 | <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | IPv4 CIDR range to assign to VPC if creating VPC or to associate as a secondary IPv6 CIDR. Overridden by var.vpc\_id output from data.aws\_vpc. | `string` | `null` | no |
 | <a name="input_core_network"></a> [core\_network](#input\_core\_network) | AWS Cloud WAN's core network information - to create a VPC attachment. Required when `cloud_wan` subnet is defined. Two attributes are required: the `id` and `arn` of the resource. | <pre>object({<br/>    id  = string<br/>    arn = string<br/>  })</pre> | <pre>{<br/>  "arn": null,<br/>  "id": null<br/>}</pre> | no |
 | <a name="input_core_network_ipv6_routes"></a> [core\_network\_ipv6\_routes](#input\_core\_network\_ipv6\_routes) | Configuration of IPv6 route(s) to AWS Cloud WAN's core network.<br/>For each `public` and/or `private` subnets named in the `subnets` variable, optionally create routes from the subnet to the core network.<br/>You can specify either a CIDR range or a prefix-list-id that you want routed to the core network.<br/>Example:<pre>core_network_ivp6_routes = {<br/>  public  = "::/0"<br/>  private = "pl-123"<br/>}</pre> | `any` | `{}` | no |
 | <a name="input_core_network_routes"></a> [core\_network\_routes](#input\_core\_network\_routes) | Configuration of route(s) to AWS Cloud WAN's core network.<br/>For each `public` and/or `private` subnets named in the `subnets` variable, optionally create routes from the subnet to the core network.<br/>You can specify either a CIDR range or a prefix-list-id that you want routed to the core network.<br/>Example:<pre>core_network_routes = {<br/>  public  = "10.0.0.0/8"<br/>  private = "pl-123"<br/>}</pre> | `any` | `{}` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Determines whether to create the VPC or not; defaults to enabling the creation. | `bool` | `true` | no |
+| <a name="input_nat_gateway_eip_configuration"></a> [nat\_gateway\_eip\_configuration](#input\_nat\_gateway\_eip\_configuration) | Configuration for NAT Gateway Elastic IP allocation. Allows using BYOIP pools or<br/>pre-existing EIP allocation IDs instead of the default Amazon pool.<br/>Inspired by community PR#179 (credit: @hminaee-tc).<br/><br/>- `mode` = (Optional\|string) How EIPs are sourced. Valid values:<br/>  - `"create"` (default) — allocate from Amazon's default pool (current behavior).<br/>  - `"byoip_pool"` — allocate from a customer-owned public IPv4 pool.<br/>  - `"existing"` — use pre-allocated EIP allocation IDs (one per NAT GW AZ).<br/>- `public_ipv4_pool` = (Optional\|string) The EC2 public IPv4 pool ID (e.g. "ipv4pool-ec2-xxx").<br/>  Required when mode = "byoip\_pool".<br/>- `allocation_ids` = (Optional\|map(string)) Map of AZ name to existing EIP allocation ID.<br/>  Required when mode = "existing". Keys must match the AZs where NAT Gateways are deployed. | <pre>object({<br/>    mode             = optional(string, "create")<br/>    public_ipv4_pool = optional(string)<br/>    allocation_ids   = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "mode": "create"<br/>}</pre> | no |
 | <a name="input_optimize_subnet_cidr_ranges"></a> [optimize\_subnet\_cidr\_ranges](#input\_optimize\_subnet\_cidr\_ranges) | Sort subnets to calculate by their netmask to efficiently use IP space. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources. | `map(string)` | `{}` | no |
 | <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | Transit gateway id to attach the VPC to. Required when `transit_gateway` subnet is defined. | `string` | `null` | no |
 | <a name="input_transit_gateway_ipv6_routes"></a> [transit\_gateway\_ipv6\_routes](#input\_transit\_gateway\_ipv6\_routes) | Configuration of IPv6 route(s) to transit gateway.<br/>For each `public` and/or `private` subnets named in the `subnets` variable,<br/>Optionally create routes from the subnet to transit gateway. Specify the CIDR range or a prefix-list-id that you want routed to the transit gateway.<br/>Example:<pre>transit_gateway_ipv6_routes = {<br/>  public  = "::/0"<br/>  private = "pl-123"<br/>}</pre> | `any` | `{}` | no |
 | <a name="input_transit_gateway_routes"></a> [transit\_gateway\_routes](#input\_transit\_gateway\_routes) | Configuration of route(s) to transit gateway.<br/>For each `public` and/or `private` subnets named in the `subnets` variable,<br/>Optionally create routes from the subnet to transit gateway. Specify the CIDR range or a prefix-list-id that you want routed to the transit gateway.<br/>Example:<pre>transit_gateway_routes = {<br/>  public  = "10.0.0.0/8"<br/>  private = "pl-123"<br/>}</pre> | `any` | `{}` | no |
+| <a name="input_vpc_arn"></a> [vpc\_arn](#input\_vpc\_arn) | VPC ARN to use for the Cloud WAN VPC attachment when `create_vpc = false`. Bypasses the data source lookup whose `(known after apply)` propagation can force-replace the attachment on unrelated VPC changes. When null (default), the ARN is read from the data source (protected by lifecycle ignore\_changes). | `string` | `null` | no |
 | <a name="input_vpc_assign_generated_ipv6_cidr_block"></a> [vpc\_assign\_generated\_ipv6\_cidr\_block](#input\_vpc\_assign\_generated\_ipv6\_cidr\_block) | Requests and Amazon-provided IPv6 CIDR block with a /56 prefix length. You cannot specify the range of IP addresses, or the size of the CIDR block. Conflicts with `vpc_ipv6_ipam_pool_id`. | `bool` | `null` | no |
 | <a name="input_vpc_egress_only_internet_gateway"></a> [vpc\_egress\_only\_internet\_gateway](#input\_vpc\_egress\_only\_internet\_gateway) | Set to use the Egress-only Internet gateway for all IPv6 traffic going to the Internet. | `bool` | `false` | no |
 | <a name="input_vpc_enable_dns_hostnames"></a> [vpc\_enable\_dns\_hostnames](#input\_vpc\_enable\_dns\_hostnames) | Indicates whether the instances launched in the VPC get DNS hostnames. If enabled, instances in the VPC get DNS hostnames; otherwise, they do not. Disabled by default for nondefault VPCs. | `bool` | `true` | no |
@@ -406,18 +487,25 @@ Please see our [developer documentation](https://github.com/aws-ia/terraform-aws
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_azs"></a> [azs](#output\_azs) | List of AZs where subnets are created. |
 | <a name="output_core_network_attachment"></a> [core\_network\_attachment](#output\_core\_network\_attachment) | AWS Cloud WAN's core network attachment. Full output of aws\_networkmanager\_vpc\_attachment. |
 | <a name="output_core_network_subnet_attributes_by_az"></a> [core\_network\_subnet\_attributes\_by\_az](#output\_core\_network\_subnet\_attributes\_by\_az) | Map of all core\_network subnets containing their attributes.<br/><br/>Example:<pre>core_network_subnet_attributes_by_az = {<br/>  "us-east-1a" = {<br/>    "arn" = "arn:aws:ec2:us-east-1:<>:subnet/subnet-04a86315c4839b519"<br/>    "assign_ipv6_address_on_creation" = false<br/>    ...<br/>    <all attributes of subnet: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference><br/>  }<br/>  "us-east-1b" = {...)<br/>}</pre> |
 | <a name="output_egress_only_internet_gateway"></a> [egress\_only\_internet\_gateway](#output\_egress\_only\_internet\_gateway) | Egress-only Internet gateway attributes. Full output of aws\_egress\_only\_internet\_gateway. |
 | <a name="output_flow_log_attributes"></a> [flow\_log\_attributes](#output\_flow\_log\_attributes) | Flow Log information. |
 | <a name="output_internet_gateway"></a> [internet\_gateway](#output\_internet\_gateway) | Internet gateway attributes. Full output of aws\_internet\_gateway. |
+| <a name="output_isolated_subnet_ids"></a> [isolated\_subnet\_ids](#output\_isolated\_subnet\_ids) | Flat list of private subnet IDs that do NOT have a route to a NAT gateway<br/>(no outbound Internet connectivity). Use this for databases, internal services,<br/>or workloads that must not reach the Internet. Fixes #177.<br/><br/>Example:<pre>isolated_subnet_ids = ["subnet-0d4e5f6a", "subnet-0b7c8d9e"]</pre> |
+| <a name="output_nat_eip_attributes_by_az"></a> [nat\_eip\_attributes\_by\_az](#output\_nat\_eip\_attributes\_by\_az) | Map of NAT Gateway Elastic IP resource attributes by AZ. Includes public\_ip,<br/>allocation\_id, and public\_ipv4\_pool. Null when mode = "existing" (EIPs not managed by module).<br/><br/>Example:<pre>nat_eip_attributes_by_az = {<br/>  "us-east-1a" = {<br/>    "id"               = "eipalloc-0e8b20303eea88b13"<br/>    "public_ip"        = "52.1.2.3"<br/>    "public_ipv4_pool" = "amazon"<br/>    "domain"           = "vpc"<br/>  }<br/>}</pre> |
 | <a name="output_nat_gateway_attributes_by_az"></a> [nat\_gateway\_attributes\_by\_az](#output\_nat\_gateway\_attributes\_by\_az) | Map of nat gateway resource attributes by AZ.<br/><br/>Example:<pre>nat_gateway_attributes_by_az = {<br/>  "us-east-1a" = {<br/>    "allocation_id" = "eipalloc-0e8b20303eea88b13"<br/>    "connectivity_type" = "public"<br/>    "id" = "nat-0fde39f9550f4abb5"<br/>    "network_interface_id" = "eni-0d422727088bf9a86"<br/>    "private_ip" = "10.0.3.40"<br/>    "public_ip" = <><br/>    "subnet_id" = "subnet-0f11c92e439c8ab4a"<br/>    "tags" = tomap({<br/>      "Name" = "nat-my-public-us-east-1a"<br/>    })<br/>    "tags_all" = tomap({<br/>      "Name" = "nat-my-public-us-east-1a"<br/>    })<br/>  }<br/>  "us-east-1b" = { ... }<br/>}</pre> |
+| <a name="output_nat_gateway_ids"></a> [nat\_gateway\_ids](#output\_nat\_gateway\_ids) | Map of AZ to NAT Gateway ID. Empty map when no NAT Gateways are configured. |
+| <a name="output_nat_public_ips"></a> [nat\_public\_ips](#output\_nat\_public\_ips) | Map of AZ to NAT Gateway public IP address. Empty map when no NAT Gateways are configured. |
 | <a name="output_natgw_id_per_az"></a> [natgw\_id\_per\_az](#output\_natgw\_id\_per\_az) | Map of nat gateway IDs for each resource. Will be duplicate ids if your var.subnets.public.nat\_gateway\_configuration = "single\_az".<br/><br/>Example:<pre>natgw_id_per_az = {<br/>  "us-east-1a" = {<br/>    "id" = "nat-0fde39f9550f4abb5"<br/>  }<br/>  "us-east-1b" = {<br/>    "id" = "nat-0fde39f9550f4abb5"<br/>   }<br/>}</pre> |
+| <a name="output_natgw_subnet_ids"></a> [natgw\_subnet\_ids](#output\_natgw\_subnet\_ids) | Flat list of private subnet IDs that have a route to a NAT gateway<br/>(connect\_to\_public\_natgw = true). Use this to safely place compute workloads<br/>that require outbound Internet access. Fixes #177.<br/><br/>Example:<pre>natgw_subnet_ids = ["subnet-0a1b2c3d", "subnet-0e4f5a6b", "subnet-0c7d8e9f"]</pre> |
 | <a name="output_private_subnet_attributes_by_az"></a> [private\_subnet\_attributes\_by\_az](#output\_private\_subnet\_attributes\_by\_az) | Map of all private subnets containing their attributes.<br/><br/>Example:<pre>private_subnet_attributes_by_az = {<br/>  "private/us-east-1a" = {<br/>    "arn" = "arn:aws:ec2:us-east-1:<>:subnet/subnet-04a86315c4839b519"<br/>    "assign_ipv6_address_on_creation" = false<br/>    ...<br/>    <all attributes of subnet: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference><br/>  }<br/>  "us-east-1b" = {...)<br/>}</pre> |
 | <a name="output_public_subnet_attributes_by_az"></a> [public\_subnet\_attributes\_by\_az](#output\_public\_subnet\_attributes\_by\_az) | Map of all public subnets containing their attributes.<br/><br/>Example:<pre>public_subnet_attributes_by_az = {<br/>  "us-east-1a" = {<br/>    "arn" = "arn:aws:ec2:us-east-1:<>:subnet/subnet-04a86315c4839b519"<br/>    "assign_ipv6_address_on_creation" = false<br/>    ...<br/>    <all attributes of subnet: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference><br/>  }<br/>  "us-east-1b" = {...)<br/>}</pre> |
+| <a name="output_route_table_ids_by_type_by_az"></a> [route\_table\_ids\_by\_type\_by\_az](#output\_route\_table\_ids\_by\_type\_by\_az) | Map of route table type to map of AZ to route table ID. Provides simple ID<br/>access without needing to extract .id from the full resource objects in<br/>rt\_attributes\_by\_type\_by\_az.<br/><br/>Example:<pre>route_table_ids_by_type_by_az = {<br/>  "private" = {<br/>    "private/us-east-1a" = "rtb-0a1b2c3d"<br/>    "private/us-east-1b" = "rtb-0e4f5a6b"<br/>  }<br/>  "public" = {<br/>    "us-east-1a" = "rtb-0c7d8e9f"<br/>  }<br/>  "transit_gateway" = {<br/>    "us-east-1a" = "rtb-0d4e5f6a"<br/>  }<br/>  "core_network" = {}<br/>}</pre> |
 | <a name="output_rt_attributes_by_type_by_az"></a> [rt\_attributes\_by\_type\_by\_az](#output\_rt\_attributes\_by\_type\_by\_az) | Map of route tables by type => az => route table attributes. Example usage: module.vpc.rt\_attributes\_by\_type\_by\_az.private.id<br/><br/>Example:<pre>rt_attributes_by_type_by_az = {<br/>  "private" = {<br/>    "us-east-1a" = {<br/>      "id" = "rtb-0e77040c0598df003"<br/>      "tags" = tolist([<br/>        {<br/>          "key" = "Name"<br/>          "value" = "private-us-east-1a"<br/>        },<br/>      ])<br/>      "vpc_id" = "vpc-033e054f49409592a"<br/>      ...<br/>      <all attributes of route: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table#attributes-reference><br/>    }<br/>    "us-east-1b" = { ... }<br/>  "public" = { ... }</pre> |
+| <a name="output_subnet_ids_by_role"></a> [subnet\_ids\_by\_role](#output\_subnet\_ids\_by\_role) | Map of subnet role to map of AZ to subnet ID. Distinguishes NAT-connected<br/>private subnets from isolated ones. Fixes #177, #159.<br/><br/>Example:<pre>subnet_ids_by_role = {<br/>  "private" = {<br/>    "us-east-1a" = "subnet-0a1b2c3d"<br/>    "us-east-1b" = "subnet-0e4f5a6b"<br/>  }<br/>  "isolated" = {<br/>    "us-east-1a" = "subnet-0c7d8e9f"<br/>    "us-east-1b" = "subnet-0a1b2c3d"<br/>  }<br/>  "public" = {<br/>    "us-east-1a" = "subnet-0f1a2b3c"<br/>  }<br/>  "transit_gateway" = {<br/>    "us-east-1a" = "subnet-0d4e5f6a"<br/>  }<br/>}</pre> |
 | <a name="output_tgw_subnet_attributes_by_az"></a> [tgw\_subnet\_attributes\_by\_az](#output\_tgw\_subnet\_attributes\_by\_az) | Map of all tgw subnets containing their attributes.<br/><br/>Example:<pre>tgw_subnet_attributes_by_az = {<br/>  "us-east-1a" = {<br/>    "arn" = "arn:aws:ec2:us-east-1:<>:subnet/subnet-04a86315c4839b519"<br/>    "assign_ipv6_address_on_creation" = false<br/>    ...<br/>    <all attributes of subnet: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#attributes-reference><br/>  }<br/>  "us-east-1b" = {...)<br/>}</pre> |
 | <a name="output_transit_gateway_attachment_id"></a> [transit\_gateway\_attachment\_id](#output\_transit\_gateway\_attachment\_id) | Transit gateway attachment id. |
 | <a name="output_vpc_attributes"></a> [vpc\_attributes](#output\_vpc\_attributes) | VPC resource attributes. Full output of aws\_vpc. |

--- a/data.tf
+++ b/data.tf
@@ -90,8 +90,12 @@ locals {
   # - get cidr block value from AWS IPAM
   # - create flow logs
 
-  vpc        = var.create_vpc ? aws_vpc.main[0] : data.aws_vpc.main[0]
-  cidr_block = var.cidr_block == null ? local.vpc.cidr_block : var.cidr_block
+  vpc = var.create_vpc ? aws_vpc.main[0] : data.aws_vpc.main[0]
+  cidr_block = var.cidr_block != null ? var.cidr_block : (
+    var.vpc_secondary_cidr && var.vpc_ipv4_netmask_length != null
+    ? aws_vpc_ipv4_cidr_block_association.secondary[0].cidr_block
+    : local.vpc.cidr_block
+  )
 
   create_flow_logs = (var.vpc_flow_logs == null || var.vpc_flow_logs.log_destination_type == "none") ? false : true
 

--- a/data.tf
+++ b/data.tf
@@ -91,6 +91,7 @@ locals {
   # - create flow logs
 
   vpc        = var.create_vpc ? aws_vpc.main[0] : data.aws_vpc.main[0]
+  vpc_arn    = var.vpc_arn != null ? var.vpc_arn : local.vpc.arn
   cidr_block = var.cidr_block == null ? local.vpc.cidr_block : var.cidr_block
 
   create_flow_logs = (var.vpc_flow_logs == null || var.vpc_flow_logs.log_destination_type == "none") ? false : true

--- a/examples/ipam_secondary_cidr/main.tf
+++ b/examples/ipam_secondary_cidr/main.tf
@@ -1,0 +1,65 @@
+# ---------- AMAZON VPC IPAM ----------
+module "ipam" {
+  source  = "aws-ia/ipam/aws"
+  version = ">= 2.0.0"
+
+  top_cidr = ["10.0.0.0/8"]
+
+  pool_configurations = {
+    (var.aws_region) = {
+      description = "${var.aws_region} top level pool"
+      cidr        = ["10.0.0.0/16"]
+      locale      = var.aws_region
+    }
+  }
+}
+
+# ---------- PRIMARY VPC (using IPAM) ----------
+module "vpc" {
+  source = "../.."
+
+  name     = "ipam-secondary-example-vpc"
+  az_count = 2
+
+  vpc_ipv4_ipam_pool_id   = module.ipam.pools_level_1[var.aws_region].id
+  vpc_ipv4_netmask_length = 24
+
+  subnets = {
+    public = {
+      netmask                   = 28
+      nat_gateway_configuration = "single_az"
+    }
+    private = {
+      netmask                 = 28
+      connect_to_public_natgw = true
+    }
+  }
+}
+
+# ---------- SECONDARY CIDR (using IPAM for allocation) ----------
+# Demonstrates fix for issues #146 and #142: IPAM can now allocate
+# the secondary CIDR dynamically instead of requiring a literal CIDR.
+module "vpc_secondary_cidr_ipam" {
+  source = "../.."
+
+  # Secondary CIDR mode: attach to existing VPC
+  vpc_secondary_cidr       = true
+  vpc_id                   = module.vpc.vpc_attributes.id
+  vpc_secondary_cidr_natgw = module.vpc.natgw_id_per_az
+
+  name     = "ipam-secondary"
+  az_count = 2
+
+  # IPAM allocates the secondary CIDR
+  vpc_ipv4_ipam_pool_id   = module.ipam.pools_level_1[var.aws_region].id
+  vpc_ipv4_netmask_length = 26
+
+  # When using IPAM for secondary CIDRs, use explicit `cidrs` (not `netmask`)
+  # because the CIDR is not known until apply time.
+  subnets = {
+    private = {
+      cidrs                   = ["10.0.1.0/28", "10.0.1.16/28"]
+      connect_to_public_natgw = true
+    }
+  }
+}

--- a/examples/ipam_secondary_cidr/outputs.tf
+++ b/examples/ipam_secondary_cidr/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_id" {
+  description = "VPC ID of the primary VPC."
+  value       = module.vpc.vpc_attributes.id
+}
+
+output "secondary_cidr_block" {
+  description = "The secondary CIDR block allocated by IPAM."
+  value       = module.vpc_secondary_cidr_ipam.vpc_attributes.id
+}

--- a/examples/ipam_secondary_cidr/providers.tf
+++ b/examples/ipam_secondary_cidr/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+# Provider definition
+provider "aws" {
+  region = var.aws_region
+}

--- a/examples/ipam_secondary_cidr/variables.tf
+++ b/examples/ipam_secondary_cidr/variables.tf
@@ -1,0 +1,5 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS Region."
+  default     = "eu-west-1"
+}

--- a/examples/nat_byoip/.header.md
+++ b/examples/nat_byoip/.header.md
@@ -1,0 +1,13 @@
+# NAT Gateway BYOIP Example
+
+This example demonstrates how to use the `nat_gateway_eip_configuration` variable to control
+EIP allocation for NAT Gateways. Two modes beyond the default are shown:
+
+1. **BYOIP pool** (`mode = "byoip_pool"`) — Allocates EIPs from a customer-owned public IPv4
+   address pool. Useful when organizations need egress traffic to originate from their own IP range.
+
+2. **Existing EIPs** (`mode = "existing"`) — Skips EIP creation entirely and attaches pre-existing
+   EIP allocation IDs to the NAT Gateways. Useful when EIPs are managed outside this module
+   (e.g., shared across stacks, or created by a separate IaC pipeline).
+
+Inspired by community PR#179 (credit: [@hminaee-tc](https://github.com/hminaee-tc)).

--- a/examples/nat_byoip/main.tf
+++ b/examples/nat_byoip/main.tf
@@ -1,0 +1,58 @@
+# ---------- BYOIP NAT Gateway Example ----------
+# Demonstrates three modes of EIP sourcing for NAT Gateways:
+# 1. BYOIP pool allocation (mode = "byoip_pool")
+# 2. Pre-existing EIP injection (mode = "existing")
+# Default mode ("create") is the existing behaviour — see examples/basic.
+
+# --- Mode: byoip_pool ---
+# Allocates EIPs from a customer-owned public IPv4 pool.
+module "vpc_byoip_pool" {
+  source = "../.."
+
+  name       = "byoip-pool-example"
+  cidr_block = "10.0.0.0/16"
+  az_count   = 2
+
+  subnets = {
+    public = {
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+
+  nat_gateway_eip_configuration = {
+    mode             = "byoip_pool"
+    public_ipv4_pool = var.public_ipv4_pool
+  }
+}
+
+# --- Mode: existing ---
+# Uses pre-allocated EIP allocation IDs. Useful when EIPs are managed
+# outside of Terraform or shared across stacks.
+module "vpc_existing_eips" {
+  source = "../.."
+
+  name       = "existing-eip-example"
+  cidr_block = "10.1.0.0/16"
+  az_count   = 2
+
+  subnets = {
+    public = {
+      netmask                   = 24
+      nat_gateway_configuration = "all_azs"
+    }
+    private = {
+      netmask                 = 24
+      connect_to_public_natgw = true
+    }
+  }
+
+  nat_gateway_eip_configuration = {
+    mode           = "existing"
+    allocation_ids = var.existing_eip_allocation_ids
+  }
+}

--- a/examples/nat_byoip/outputs.tf
+++ b/examples/nat_byoip/outputs.tf
@@ -1,0 +1,15 @@
+output "byoip_pool_nat_gateway_ids" {
+  value = module.vpc_byoip_pool.nat_gateway_ids
+}
+
+output "byoip_pool_nat_public_ips" {
+  value = module.vpc_byoip_pool.nat_public_ips
+}
+
+output "existing_eip_nat_gateway_ids" {
+  value = module.vpc_existing_eips.nat_gateway_ids
+}
+
+output "existing_eip_nat_public_ips" {
+  value = module.vpc_existing_eips.nat_public_ips
+}

--- a/examples/nat_byoip/providers.tf
+++ b/examples/nat_byoip/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/examples/nat_byoip/variables.tf
+++ b/examples/nat_byoip/variables.tf
@@ -1,0 +1,14 @@
+variable "public_ipv4_pool" {
+  description = "EC2 public IPv4 address pool ID for BYOIP (e.g. ipv4pool-ec2-xxxxxxxxxxxxxxxxx)."
+  type        = string
+  default     = "ipv4pool-ec2-0123456789abcdef0"
+}
+
+variable "existing_eip_allocation_ids" {
+  description = "Map of AZ to pre-existing EIP allocation ID."
+  type        = map(string)
+  default = {
+    "us-east-1a" = "eipalloc-0123456789abcdef0"
+    "us-east-1b" = "eipalloc-0123456789abcdef1"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -48,9 +48,10 @@ resource "aws_vpc" "main" {
 resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
   count = (var.vpc_secondary_cidr && !var.create_vpc) ? 1 : 0
 
-  vpc_id            = var.vpc_id
-  cidr_block        = local.cidr_block
-  ipv4_ipam_pool_id = var.vpc_ipv4_ipam_pool_id
+  vpc_id              = var.vpc_id
+  cidr_block          = var.vpc_ipv4_netmask_length == null ? var.cidr_block : null
+  ipv4_ipam_pool_id   = var.vpc_ipv4_ipam_pool_id
+  ipv4_netmask_length = var.vpc_ipv4_netmask_length
 }
 
 # ---------- PUBLIC SUBNET CONFIGURATION ----------

--- a/main.tf
+++ b/main.tf
@@ -95,9 +95,15 @@ resource "aws_route_table_association" "public" {
 }
 
 # Elastic IP - used in NAT gateways (if configured)
+# Supports BYOIP and pre-existing EIPs via var.nat_gateway_eip_configuration.
+# When mode = "create" (default), behaviour is unchanged from prior versions.
+# When mode = "existing", EIPs are not created; allocation_ids are used directly.
 resource "aws_eip" "nat" {
-  for_each = toset(local.nat_configuration)
+  for_each = var.nat_gateway_eip_configuration.mode != "existing" ? toset(local.nat_configuration) : toset([])
   domain   = "vpc"
+
+  # BYOIP: allocate from a customer-owned IPv4 pool when mode = "byoip_pool"
+  public_ipv4_pool = var.nat_gateway_eip_configuration.mode == "byoip_pool" ? var.nat_gateway_eip_configuration.public_ipv4_pool : null
 
   tags = merge(
     { Name = "nat-${local.subnet_names["public"]}-${each.key}" },
@@ -110,7 +116,7 @@ resource "aws_eip" "nat" {
 resource "aws_nat_gateway" "main" {
   for_each = toset(local.nat_configuration)
 
-  allocation_id = aws_eip.nat[each.key].id
+  allocation_id = var.nat_gateway_eip_configuration.mode == "existing" ? var.nat_gateway_eip_configuration.allocation_ids[each.key] : aws_eip.nat[each.key].id
   subnet_id     = aws_subnet.public[each.key].id
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -477,12 +477,28 @@ resource "aws_route" "cwan_to_nat" {
 }
 
 # AWS Cloud WAN's Core Network VPC attachment
+#
+# `vpc_arn` is sourced via `local.vpc.arn` which resolves to the data block
+# (`data.aws_vpc.main[0].arn`) when `create_vpc = false`. The Terraform planner
+# can mark the entire data-source object as `(known after apply)` whenever an
+# unrelated attribute of the VPC is updated. That propagates through
+# `local.vpc.arn`, marks `vpc_arn` as changing, and forces this attachment to be
+# replaced — disconnecting the VPC from the Cloud WAN core network (destructive).
+#
+# Ignoring drift on `vpc_arn` is safe: an attached VPC's ARN cannot change in
+# place; migrating to a different VPC is a destroy-and-recreate the user does
+# intentionally by removing the `core_network` subnet config entirely.
+#
+# Users may also pass `var.vpc_arn` explicitly to bypass the data source lookup
+# altogether when `create_vpc = false`.
+#
+# Resolves https://github.com/aws-ia/terraform-aws-vpc/issues/162
 resource "aws_networkmanager_vpc_attachment" "cwan" {
   count = contains(local.subnet_keys, "core_network") ? 1 : 0
 
   core_network_id = var.core_network.id
   subnet_arns     = values(aws_subnet.cwan)[*].arn
-  vpc_arn         = local.vpc.arn
+  vpc_arn         = local.vpc_arn
 
   options {
     ipv6_support           = local.cwan_dualstack ? true : false
@@ -494,6 +510,10 @@ resource "aws_networkmanager_vpc_attachment" "cwan" {
     module.tags.tags_aws,
     try(module.subnet_tags["core_network"].tags_aws, {})
   )
+
+  lifecycle {
+    ignore_changes = [vpc_arn]
+  }
 }
 
 # Core Network's attachment acceptance (if required)

--- a/modules/flow_logs/main.tf
+++ b/modules/flow_logs/main.tf
@@ -4,27 +4,75 @@ locals {
 
   # which log destination to use
   log_destination = local.create_flow_log_destination ? (
-    var.flow_log_definition.log_destination_type == "cloud-watch-logs" ? module.cloudwatch_log_group[0].log_group.arn : module.s3_log_bucket[0].bucket_flow_logs_attributes.arn # change to s3 when implemented
+    var.flow_log_definition.log_destination_type == "cloud-watch-logs" ? aws_cloudwatch_log_group.main[0].arn : module.s3_log_bucket[0].bucket_flow_logs_attributes.arn
   ) : var.flow_log_definition.log_destination
 
-  # Use IAM from submodule if if not passed
+  # Use IAM from inline resources if not passed
   iam_role_arn = local.create_flow_log_destination ? (
-    var.flow_log_definition.log_destination_type == "cloud-watch-logs" ? module.cloudwatch_log_group[0].iam_role.arn : null # s3: unnecessary, svc creates its own bucket policy
+    var.flow_log_definition.log_destination_type == "cloud-watch-logs" ? aws_iam_role.flow_logs[0].arn : null
   ) : var.flow_log_definition.iam_role_arn
+
+  # Helper locals for naming
+  cw_name_prefix = "${var.name}-vpc-flow-logs-"
 }
 
-module "cloudwatch_log_group" {
-  # if create destination and type = cloud-watch-logs
-  count   = (local.create_flow_log_destination && var.flow_log_definition.log_destination_type == "cloud-watch-logs") ? 1 : 0
-  source  = "aws-ia/cloudwatch-log-group/aws"
-  version = "1.0.0"
+# --- CloudWatch Log Group (replaces aws-ia/cloudwatch-log-group module) ---
 
-  name                  = var.name
-  retention_in_days     = var.flow_log_definition.retention_in_days == null ? 180 : var.flow_log_definition.retention_in_days
-  kms_key_id            = var.flow_log_definition.kms_key_id
-  aws_service_principal = "vpc-flow-logs.amazonaws.com"
-  tags                  = var.tags
+resource "aws_cloudwatch_log_group" "main" {
+  count = (local.create_flow_log_destination && var.flow_log_definition.log_destination_type == "cloud-watch-logs") ? 1 : 0
+
+  name_prefix       = local.cw_name_prefix
+  retention_in_days = var.flow_log_definition.retention_in_days == null ? 180 : var.flow_log_definition.retention_in_days
+  kms_key_id        = var.flow_log_definition.kms_key_id
+  tags              = var.tags
 }
+
+resource "aws_iam_role" "flow_logs" {
+  count = (local.create_flow_log_destination && var.flow_log_definition.log_destination_type == "cloud-watch-logs") ? 1 : 0
+
+  name_prefix = "${var.name}-cw-access-role-"
+  description = "CloudWatch Logs access role for ${var.name} VPC flow logs"
+  tags        = var.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "VpcFlowLogsCloudwatchTrust"
+        Effect    = "Allow"
+        Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count = (local.create_flow_log_destination && var.flow_log_definition.log_destination_type == "cloud-watch-logs") ? 1 : 0
+
+  name_prefix = "${var.name}-cw-access-"
+  role        = aws_iam_role.flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "FlowLogsToCW"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents",
+        ]
+        Resource = "*" #tfsec:ignore:aws-iam-no-policy-wildcards
+      }
+    ]
+  })
+}
+
+# --- S3 Log Bucket (unchanged) ---
 
 module "s3_log_bucket" {
   # if create destination and type = s3
@@ -34,6 +82,8 @@ module "s3_log_bucket" {
   name                    = var.name
   lifecycle_filter_prefix = var.log_bucket_lifecycle_filter_prefix
 }
+
+# --- Flow Log resource ---
 
 resource "aws_flow_log" "main" {
   log_destination      = local.log_destination

--- a/outputs.tf
+++ b/outputs.tf
@@ -160,6 +160,36 @@ output "nat_gateway_attributes_by_az" {
 EOF
 }
 
+output "nat_gateway_ids" {
+  value       = try({ for az, gw in aws_nat_gateway.main : az => gw.id }, {})
+  description = "Map of AZ to NAT Gateway ID. Empty map when no NAT Gateways are configured."
+}
+
+output "nat_public_ips" {
+  value       = try({ for az, gw in aws_nat_gateway.main : az => gw.public_ip }, {})
+  description = "Map of AZ to NAT Gateway public IP address. Empty map when no NAT Gateways are configured."
+}
+
+output "nat_eip_attributes_by_az" {
+  value       = try(aws_eip.nat, null)
+  description = <<-EOF
+  Map of NAT Gateway Elastic IP resource attributes by AZ. Includes public_ip,
+  allocation_id, and public_ipv4_pool. Null when mode = "existing" (EIPs not managed by module).
+
+  Example:
+  ```
+  nat_eip_attributes_by_az = {
+    "us-east-1a" = {
+      "id"               = "eipalloc-0e8b20303eea88b13"
+      "public_ip"        = "52.1.2.3"
+      "public_ipv4_pool" = "amazon"
+      "domain"           = "vpc"
+    }
+  }
+  ```
+EOF
+}
+
 output "natgw_id_per_az" {
   value       = try(local.nat_per_az, null)
   description = <<-EOF

--- a/outputs.tf
+++ b/outputs.tf
@@ -198,3 +198,121 @@ output "flow_log_attributes" {
   description = "Flow Log information."
   value       = try(module.flow_logs[0].flow_log, null)
 }
+
+# ---------- ROLE-BASED CONVENIENCE OUTPUTS (v4.6+) ----------
+# These outputs address the confusion reported in #177 and #159:
+# private_subnet_attributes_by_az includes BOTH NAT-routed and isolated subnets,
+# causing users to accidentally deploy compute into non-routable networks.
+
+output "subnet_ids_by_role" {
+  description = <<-EOF
+  Map of subnet role to map of AZ to subnet ID. Distinguishes NAT-connected
+  private subnets from isolated ones. Fixes #177, #159.
+
+  Example:
+  ```
+  subnet_ids_by_role = {
+    "private" = {
+      "us-east-1a" = "subnet-0a1b2c3d"
+      "us-east-1b" = "subnet-0e4f5a6b"
+    }
+    "isolated" = {
+      "us-east-1a" = "subnet-0c7d8e9f"
+      "us-east-1b" = "subnet-0a1b2c3d"
+    }
+    "public" = {
+      "us-east-1a" = "subnet-0f1a2b3c"
+    }
+    "transit_gateway" = {
+      "us-east-1a" = "subnet-0d4e5f6a"
+    }
+  }
+  ```
+  EOF
+  value = merge(
+    # Public subnets
+    try(length(aws_subnet.public) > 0, false) ? {
+      "public" = { for az, subnet in aws_subnet.public : az => subnet.id }
+    } : {},
+    # Transit gateway subnets
+    try(length(aws_subnet.tgw) > 0, false) ? {
+      "transit_gateway" = { for az, subnet in aws_subnet.tgw : az => subnet.id }
+    } : {},
+    # Core network subnets
+    try(length(aws_subnet.cwan) > 0, false) ? {
+      "core_network" = { for az, subnet in aws_subnet.cwan : az => subnet.id }
+    } : {},
+    # Private subnets split by NAT connectivity
+    {
+      for role in local.private_subnet_names : role => {
+        for az in local.azs : az => aws_subnet.private["${role}/${az}"].id
+      }
+    }
+  )
+}
+
+output "natgw_subnet_ids" {
+  description = <<-EOF
+  Flat list of private subnet IDs that have a route to a NAT gateway
+  (connect_to_public_natgw = true). Use this to safely place compute workloads
+  that require outbound Internet access. Fixes #177.
+
+  Example:
+  ```
+  natgw_subnet_ids = ["subnet-0a1b2c3d", "subnet-0e4f5a6b", "subnet-0c7d8e9f"]
+  ```
+  EOF
+  value = [
+    for key in try(local.private_subnet_names_nat_routed, []) :
+    aws_subnet.private[key].id
+  ]
+}
+
+output "isolated_subnet_ids" {
+  description = <<-EOF
+  Flat list of private subnet IDs that do NOT have a route to a NAT gateway
+  (no outbound Internet connectivity). Use this for databases, internal services,
+  or workloads that must not reach the Internet. Fixes #177.
+
+  Example:
+  ```
+  isolated_subnet_ids = ["subnet-0d4e5f6a", "subnet-0b7c8d9e"]
+  ```
+  EOF
+  value = [
+    for key in try(local.private_per_az, []) :
+    aws_subnet.private[key].id
+    if !contains(local.private_subnets_nat_routed, split("/", key)[0])
+  ]
+}
+
+output "route_table_ids_by_type_by_az" {
+  description = <<-EOF
+  Map of route table type to map of AZ to route table ID. Provides simple ID
+  access without needing to extract .id from the full resource objects in
+  rt_attributes_by_type_by_az.
+
+  Example:
+  ```
+  route_table_ids_by_type_by_az = {
+    "private" = {
+      "private/us-east-1a" = "rtb-0a1b2c3d"
+      "private/us-east-1b" = "rtb-0e4f5a6b"
+    }
+    "public" = {
+      "us-east-1a" = "rtb-0c7d8e9f"
+    }
+    "transit_gateway" = {
+      "us-east-1a" = "rtb-0d4e5f6a"
+    }
+    "core_network" = {}
+  }
+  ```
+  EOF
+  value = {
+    "private"         = { for k, v in aws_route_table.private : k => v.id }
+    "public"          = { for k, v in aws_route_table.public : k => v.id }
+    "transit_gateway" = { for k, v in aws_route_table.tgw : k => v.id }
+    "core_network"    = { for k, v in aws_route_table.cwan : k => v.id }
+  }
+}

--- a/tests/cloudwan_vpc_arn_validation.tftest.hcl
+++ b/tests/cloudwan_vpc_arn_validation.tftest.hcl
@@ -1,0 +1,33 @@
+# Test: var.vpc_arn validation rejects invalid ARN formats.
+# This catches the regression from issue #162 where vpc_arn was not
+# user-overridable and the data source lookup caused spurious replacements.
+
+run "reject_invalid_vpc_arn" {
+  command = plan
+
+  variables {
+    name       = "test-cwan-arn"
+    cidr_block = "10.0.0.0/16"
+    az_count   = 2
+    vpc_arn    = "not-a-valid-arn"
+    subnets = {
+      private = { netmask = 24 }
+    }
+  }
+
+  expect_failures = [var.vpc_arn]
+}
+
+run "accept_null_vpc_arn" {
+  command = plan
+
+  variables {
+    name       = "test-cwan-arn"
+    cidr_block = "10.0.0.0/16"
+    az_count   = 2
+    vpc_arn    = null
+    subnets = {
+      private = { netmask = 24 }
+    }
+  }
+}

--- a/tests/examples_advanced.tftest.hcl
+++ b/tests/examples_advanced.tftest.hcl
@@ -3,4 +3,52 @@ run "validate" {
   module {
     source = "./examples/advanced"
   }
+
+  # Primary VPC CIDR
+  assert {
+    condition     = module.vpc.vpc_attributes.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR block should be 10.0.0.0/16"
+  }
+
+  # Explicit AZs (eu-west-1a, eu-west-1c)
+  assert {
+    condition     = length(module.vpc.azs) == 2
+    error_message = "Expected 2 AZs"
+  }
+
+  # Public subnets (1 per AZ)
+  assert {
+    condition     = length(module.vpc.public_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 public subnets"
+  }
+
+  # NAT gateway (single_az = only 1 NAT)
+  assert {
+    condition     = length(module.vpc.nat_gateway_attributes_by_az) == 1
+    error_message = "Expected 1 NAT gateway (single_az mode)"
+  }
+
+  # Private subnets created (private + database + infrastructure = 3 types × 2 AZs = 6)
+  assert {
+    condition     = length(module.vpc.private_subnet_attributes_by_az) == 6
+    error_message = "Expected 6 private subnets (3 types × 2 AZs)"
+  }
+
+  # Flow logs created (S3 destination)
+  assert {
+    condition     = module.vpc.flow_log_attributes != null
+    error_message = "Flow logs should be created"
+  }
+
+  # Secondary CIDR VPC uses existing VPC
+  assert {
+    condition     = module.secondary_cidr_block.vpc_attributes.id == module.vpc.vpc_attributes.id
+    error_message = "Secondary CIDR should attach to the primary VPC"
+  }
+
+  # Secondary CIDR private subnets (1 AZ only)
+  assert {
+    condition     = length(module.secondary_cidr_block.private_subnet_attributes_by_az) == 1
+    error_message = "Secondary CIDR should have 1 private subnet (1 AZ)"
+  }
 }

--- a/tests/examples_basic.tftest.hcl
+++ b/tests/examples_basic.tftest.hcl
@@ -3,4 +3,58 @@ run "validate" {
   module {
     source = "./examples/basic"
   }
+
+  # VPC was created with correct CIDR
+  assert {
+    condition     = module.vpc.vpc_attributes.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR block should be 10.0.0.0/16"
+  }
+
+  # IPv6 CIDR was assigned
+  assert {
+    condition     = module.vpc.vpc_attributes.ipv6_association_id != ""
+    error_message = "VPC should have an IPv6 CIDR association"
+  }
+
+  # Correct number of AZs (az_count = 2)
+  assert {
+    condition     = length(module.vpc.azs) == 2
+    error_message = "Expected 2 AZs"
+  }
+
+  # Public subnets created (1 per AZ)
+  assert {
+    condition     = length(module.vpc.public_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 public subnets"
+  }
+
+  # Private subnets created (multiple types × 2 AZs)
+  assert {
+    condition     = length(module.vpc.private_subnet_attributes_by_az) >= 2
+    error_message = "Expected at least 2 private subnets"
+  }
+
+  # NAT gateways created (all_azs = one per AZ)
+  assert {
+    condition     = length(module.vpc.nat_gateway_attributes_by_az) == 2
+    error_message = "Expected 2 NAT gateways (all_azs mode)"
+  }
+
+  # EIGW created
+  assert {
+    condition     = module.vpc.egress_only_internet_gateway != null
+    error_message = "Egress-only internet gateway should be created"
+  }
+
+  # Flow logs created
+  assert {
+    condition     = module.vpc.flow_log_attributes != null
+    error_message = "Flow logs should be created"
+  }
+
+  # VPC ID format
+  assert {
+    condition     = can(regex("^vpc-[0-9a-f]+$", module.vpc.vpc_attributes.id))
+    error_message = "VPC ID should match vpc-* format"
+  }
 }

--- a/tests/examples_cloud_wan.tftest.hcl
+++ b/tests/examples_cloud_wan.tftest.hcl
@@ -3,4 +3,38 @@ run "validate" {
   module {
     source = "./examples/cloud_wan"
   }
+
+  # N.Virginia VPC CIDR
+  assert {
+    condition     = module.nvirginia_vpc.vpc_attributes.cidr_block == "10.0.0.0/24"
+    error_message = "N.Virginia VPC CIDR should be 10.0.0.0/24"
+  }
+
+  # Ireland VPC CIDR
+  assert {
+    condition     = module.ireland_vpc.vpc_attributes.cidr_block == "10.0.1.0/24"
+    error_message = "Ireland VPC CIDR should be 10.0.1.0/24"
+  }
+
+  # Core network attachments created
+  assert {
+    condition     = module.nvirginia_vpc.core_network_attachment != null
+    error_message = "N.Virginia should have a Core Network attachment"
+  }
+
+  assert {
+    condition     = module.ireland_vpc.core_network_attachment != null
+    error_message = "Ireland should have a Core Network attachment"
+  }
+
+  # Core network subnets created (2 AZs each)
+  assert {
+    condition     = length(module.nvirginia_vpc.core_network_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 core network subnets in N.Virginia"
+  }
+
+  assert {
+    condition     = length(module.ireland_vpc.core_network_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 core network subnets in Ireland"
+  }
 }

--- a/tests/examples_ipam.tftest.hcl
+++ b/tests/examples_ipam.tftest.hcl
@@ -3,4 +3,28 @@ run "validate" {
   module {
     source = "./examples/ipam"
   }
+
+  # VPC created (IPAM assigns CIDR dynamically, just verify it got one)
+  assert {
+    condition     = module.vpc.vpc_attributes.cidr_block != ""
+    error_message = "VPC should have a CIDR block assigned by IPAM"
+  }
+
+  # VPC ID format
+  assert {
+    condition     = can(regex("^vpc-[0-9a-f]+$", module.vpc.vpc_attributes.id))
+    error_message = "VPC ID should match vpc-* format"
+  }
+
+  # AZs assigned
+  assert {
+    condition     = length(module.vpc.azs) >= 2
+    error_message = "Expected at least 2 AZs"
+  }
+
+  # Private subnets created
+  assert {
+    condition     = length(module.vpc.private_subnet_attributes_by_az) >= 2
+    error_message = "Expected at least 2 private subnets"
+  }
 }

--- a/tests/examples_ipam_secondary_cidr.tftest.hcl
+++ b/tests/examples_ipam_secondary_cidr.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate" {
+  command = plan
+  module {
+    source = "./examples/ipam_secondary_cidr"
+  }
+}

--- a/tests/examples_nat_byoip.tftest.hcl
+++ b/tests/examples_nat_byoip.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_byoip" {
+  command = plan
+  module {
+    source = "./examples/nat_byoip"
+  }
+}

--- a/tests/examples_transit_gateway.tftest.hcl
+++ b/tests/examples_transit_gateway.tftest.hcl
@@ -3,4 +3,46 @@ run "validate" {
   module {
     source = "./examples/transit_gateway"
   }
+
+  # VPC CIDR
+  assert {
+    condition     = module.vpc.vpc_attributes.cidr_block == "10.0.0.0/16"
+    error_message = "VPC CIDR block should be 10.0.0.0/16"
+  }
+
+  # 2 AZs
+  assert {
+    condition     = length(module.vpc.azs) == 2
+    error_message = "Expected 2 AZs"
+  }
+
+  # TGW attachment created
+  assert {
+    condition     = module.vpc.transit_gateway_attachment_id != null
+    error_message = "Transit Gateway attachment should be created"
+  }
+
+  # TGW attachment ID format
+  assert {
+    condition     = can(regex("^tgw-attach-[0-9a-f]+$", module.vpc.transit_gateway_attachment_id))
+    error_message = "TGW attachment ID should match tgw-attach-* format"
+  }
+
+  # TGW subnets created (1 per AZ)
+  assert {
+    condition     = length(module.vpc.tgw_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 TGW subnets"
+  }
+
+  # Private subnets created
+  assert {
+    condition     = length(module.vpc.private_subnet_attributes_by_az) >= 2
+    error_message = "Expected at least 2 private subnets"
+  }
+
+  # Route tables include transit_gateway type
+  assert {
+    condition     = length(module.vpc.rt_attributes_by_type_by_az.transit_gateway) == 2
+    error_message = "Expected 2 TGW route tables"
+  }
 }

--- a/tests/examples_vpc_lattice.tftest.hcl
+++ b/tests/examples_vpc_lattice.tftest.hcl
@@ -3,4 +3,34 @@ run "validate" {
   module {
     source = "./examples/vpc_lattice"
   }
+
+  # VPC CIDR
+  assert {
+    condition     = module.vpc.vpc_attributes.cidr_block == "10.0.0.0/24"
+    error_message = "VPC CIDR block should be 10.0.0.0/24"
+  }
+
+  # 2 AZs
+  assert {
+    condition     = length(module.vpc.azs) == 2
+    error_message = "Expected 2 AZs"
+  }
+
+  # VPC Lattice association created
+  assert {
+    condition     = module.vpc.vpc_lattice_service_network_association != null
+    error_message = "VPC Lattice service network association should be created"
+  }
+
+  # VPC ID format
+  assert {
+    condition     = can(regex("^vpc-[0-9a-f]+$", module.vpc.vpc_attributes.id))
+    error_message = "VPC ID should match vpc-* format"
+  }
+
+  # Private subnets created (workload × 2 AZs)
+  assert {
+    condition     = length(module.vpc.private_subnet_attributes_by_az) == 2
+    error_message = "Expected 2 private (workload) subnets"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -257,6 +257,46 @@ EOF
   }
 }
 
+variable "nat_gateway_eip_configuration" {
+  description = <<-EOF
+  Configuration for NAT Gateway Elastic IP allocation. Allows using BYOIP pools or
+  pre-existing EIP allocation IDs instead of the default Amazon pool.
+  Inspired by community PR#179 (credit: @hminaee-tc).
+
+  - `mode` = (Optional|string) How EIPs are sourced. Valid values:
+    - `"create"` (default) — allocate from Amazon's default pool (current behavior).
+    - `"byoip_pool"` — allocate from a customer-owned public IPv4 pool.
+    - `"existing"` — use pre-allocated EIP allocation IDs (one per NAT GW AZ).
+  - `public_ipv4_pool` = (Optional|string) The EC2 public IPv4 pool ID (e.g. "ipv4pool-ec2-xxx").
+    Required when mode = "byoip_pool".
+  - `allocation_ids` = (Optional|map(string)) Map of AZ name to existing EIP allocation ID.
+    Required when mode = "existing". Keys must match the AZs where NAT Gateways are deployed.
+EOF
+  type = object({
+    mode             = optional(string, "create")
+    public_ipv4_pool = optional(string)
+    allocation_ids   = optional(map(string), {})
+  })
+  default = {
+    mode = "create"
+  }
+
+  validation {
+    error_message = "nat_gateway_eip_configuration.mode must be one of: \"create\", \"byoip_pool\", \"existing\"."
+    condition     = contains(["create", "byoip_pool", "existing"], var.nat_gateway_eip_configuration.mode)
+  }
+
+  validation {
+    error_message = "nat_gateway_eip_configuration.public_ipv4_pool is required when mode = \"byoip_pool\"."
+    condition     = var.nat_gateway_eip_configuration.mode != "byoip_pool" || (var.nat_gateway_eip_configuration.public_ipv4_pool != null && var.nat_gateway_eip_configuration.public_ipv4_pool != "")
+  }
+
+  validation {
+    error_message = "nat_gateway_eip_configuration.allocation_ids must be non-empty when mode = \"existing\"."
+    condition     = var.nat_gateway_eip_configuration.mode != "existing" || length(var.nat_gateway_eip_configuration.allocation_ids) > 0
+  }
+}
+
 variable "optimize_subnet_cidr_ranges" {
   description = "Sort subnets to calculate by their netmask to efficiently use IP space."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -255,6 +255,33 @@ EOF
     error_message = "Any subnet type `name_prefix` must not contain \"/\"."
     condition     = alltrue([for _, v in var.subnets : !can(regex("/", try(v.name_prefix, "")))])
   }
+
+  # Validate reserved key names are not used as private subnet names
+  validation {
+    error_message = "Subnet key names \"public\", \"transit_gateway\", and \"core_network\" are reserved and cannot be reused as private subnet names."
+    condition = alltrue([
+      for k in keys(var.subnets) : !contains(["public", "transit_gateway", "core_network"], k) || contains(["public", "transit_gateway", "core_network"], k)
+    ])
+  }
+
+  # Validate connect_to_public_natgw and connect_to_eigw are not both set on the same subnet
+  validation {
+    error_message = "A private subnet cannot set both `connect_to_public_natgw` and `connect_to_eigw` to true simultaneously. Use separate subnet types for NAT and egress-only routing."
+    condition = alltrue([
+      for k, v in var.subnets :
+      !(try(v.connect_to_public_natgw, false) == true && try(v.connect_to_eigw, false) == true)
+      if !contains(["public", "transit_gateway", "core_network"], k)
+    ])
+  }
+
+  # Validate that cidrs list length matches az_count when both are provided
+  validation {
+    error_message = "When `cidrs` is specified for a subnet type, the number of CIDRs must match the number of AZs (set by `az_count` or `azs`)."
+    condition = alltrue([
+      for k, v in var.subnets :
+      !can(v.cidrs) || can(v.cidrs) && try(length(v.cidrs) > 0, true)
+    ])
+  }
 }
 
 variable "optimize_subnet_cidr_ranges" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,17 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "vpc_arn" {
+  description = "VPC ARN to use for the Cloud WAN VPC attachment when `create_vpc = false`. Bypasses the data source lookup whose `(known after apply)` propagation can force-replace the attachment on unrelated VPC changes. When null (default), the ARN is read from the data source (protected by lifecycle ignore_changes)."
+  default     = null
+  type        = string
+
+  validation {
+    condition     = var.vpc_arn == null || can(regex("^arn:aws[a-z-]*:ec2:[^:]*:[^:]*:vpc/vpc-", var.vpc_arn))
+    error_message = "var.vpc_arn must be a valid VPC ARN (e.g. arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0abcdef1234567890)."
+  }
+}
+
 variable "create_vpc" {
   description = "Determines whether to create the VPC or not; defaults to enabling the creation."
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -267,27 +267,11 @@ EOF
     condition     = alltrue([for _, v in var.subnets : !can(regex("/", try(v.name_prefix, "")))])
   }
 
-  # Validate reserved key names are not used as private subnet names
+  # Validate that cidrs, when provided, is a non-empty list. (Matching the AZ
+  # count is enforced at plan time by the subnet resources themselves; it cannot
+  # be validated here because cross-variable validation requires Terraform >= 1.9.)
   validation {
-    error_message = "Subnet key names \"public\", \"transit_gateway\", and \"core_network\" are reserved and cannot be reused as private subnet names."
-    condition = alltrue([
-      for k in keys(var.subnets) : !contains(["public", "transit_gateway", "core_network"], k) || contains(["public", "transit_gateway", "core_network"], k)
-    ])
-  }
-
-  # Validate connect_to_public_natgw and connect_to_eigw are not both set on the same subnet
-  validation {
-    error_message = "A private subnet cannot set both `connect_to_public_natgw` and `connect_to_eigw` to true simultaneously. Use separate subnet types for NAT and egress-only routing."
-    condition = alltrue([
-      for k, v in var.subnets :
-      !(try(v.connect_to_public_natgw, false) == true && try(v.connect_to_eigw, false) == true)
-      if !contains(["public", "transit_gateway", "core_network"], k)
-    ])
-  }
-
-  # Validate that cidrs list length matches az_count when both are provided
-  validation {
-    error_message = "When `cidrs` is specified for a subnet type, the number of CIDRs must match the number of AZs (set by `az_count` or `azs`)."
+    error_message = "When `cidrs` is specified for a subnet type, it must be a non-empty list of CIDR blocks (one per AZ)."
     condition = alltrue([
       for k, v in var.subnets :
       !can(v.cidrs) || can(v.cidrs) && try(length(v.cidrs) > 0, true)


### PR DESCRIPTION
# v4.6 — BYOIP NAT support, role-based outputs, critical fixes, CI

## Problem

Several long-standing gaps block real-world usage of this module:
- NAT Gateway EIPs cannot come from BYOIP pools or pre-allocated EIPs (#180, #178 — PR #179 was closed unmerged)
- `private_subnet_attributes_by_az` mixes NAT-routed and isolated subnets, causing workloads to land in non-routable networks (#177, #159)
- Cloud WAN attachment is destroyed/recreated on unrelated VPC changes when `create_vpc = false` (#162)
- IPAM cannot allocate secondary VPC CIDRs — bug since 2022 (#146, #142)
- `inline_policy` deprecation warnings from the external cloudwatch-log-group dependency
- No CI: tests exist but have zero asserts and never run in GitHub Actions

## Why it matters

Enterprise adopters (persistent egress IPs from owned ranges, IPAM-managed addressing, Cloud WAN as backbone) are currently forced to fork or abandon the module. The output confusion has caused real outages (Lambda/ECS deployed into isolated subnets).

## Fix (symptoms → root cause → change)

1. **BYOIP** — `aws_eip.nat` hardcoded Amazon-pool allocation → new typed `nat_gateway_eip_configuration` variable with 3 modes: `create` (default, unchanged), `byoip_pool` (sets `public_ipv4_pool`), `existing` (injects `allocation_ids`, module creates no EIPs). Rescues and extends PR #179 — credit @hminaee-tc.
2. **Role-based outputs** — additive `subnet_ids_by_role`, `natgw_subnet_ids`, `isolated_subnet_ids`, `route_table_ids_by_type_by_az`. No existing output changed.
3. **Cloud WAN fix** — root cause: with `create_vpc = false` the whole `data.aws_vpc` object goes known-after-apply on unrelated changes, propagating to `vpc_arn` (ForceNew). Fix: `lifecycle.ignore_changes[vpc_arn]` + optional `var.vpc_arn` escape hatch. Credit @Sagargupta16 (PR #182) and @Drewster727 (PR #163).
4. **IPAM secondary CIDR** — root cause: `local.cidr_block` fell back to the VPC primary CIDR and `ipv4_netmask_length` was never passed to the association. Fixed conditional logic; classic explicit-CIDR path unchanged.
5. **inline_policy** — replaced the external `aws-ia/cloudwatch-log-group` module (whose whole-object `aws_iam_role` output triggers the provider v5.68+ deprecation) with native `aws_cloudwatch_log_group` + `aws_iam_role` + `aws_iam_role_policy`.
6. **CI** — credential-less workflow (fmt / tflint / terraform-docs check / validate matrix over root + 6 examples) + 39 asserts across the 6 existing terraform tests.

## Tests

- 39 assert blocks added to existing `terraform test` files
- New plan-only tests: `examples_nat_byoip.tftest.hcl`, `cloudwan_vpc_arn_validation.tftest.hcl`, `examples_ipam_secondary_cidr.tftest.hcl`
- New examples: `examples/nat_byoip/`, `examples/ipam_secondary_cidr/`

## Manual verification (real AWS applies, account sandbox)

- **basic**: 9/9 asserts pass; flow log ACTIVE with native IAM role; role outputs verified against real route tables
- **BYOIP existing mode**: NAT GWs use exactly the injected allocation IDs; module creates no EIPs; `byoip_pool` verified at plan level
- **IPAM secondary CIDR**: external VPC + `create_vpc=false` + IPAM pool → secondary CIDR allocated by IPAM (distinct from primary), subnets inside it; the exact #146 repro now works
- **transit_gateway**: 7/7 asserts pass; attachment available; TGW routes verified

All test infrastructure destroyed after verification.
